### PR TITLE
support secretRef and new parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # cluster-cloud-director
 
 This repository contains the Helm chart used for deploying CAPI clusters via [CAPVCD](https://github.com/vmware/cluster-api-provider-cloud-director).
+
+## Authentication to VCD
+
+Authentication to the VCD API is achieved as part of the cluster creation process to abide by user-defined resource quotas. At the moment, it can be achieved by referencing a secret (preferred method) or specifying creds/token in the VCDCluster definition.
+
+**[Because of a bug](https://github.com/vmware/cluster-api-provider-cloud-director/issues/171), the secretRef implementation currently doesn't work and it is necessary to use the credentials/refreshToken directly in VCDCluster, as a result, set `useSecretRef: false` in `values.yaml`.** (This wouldn't be an issue if the CPI wasn't deployed in the cloud-init script - will be removed in upstream roadmap)
+
+Before deploying a cluster, make sure there is a secret containing the base64 encoded user credentials or [API token](https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html) of the VCD user in the namespace where you will deploy the cluster.
+
+### API token
+
+Using an API token is preferred for authentication over credentials as it can be revoked easily. If both credentials and an API token are specified, the credentials will be ignored. In order to create an API token:
+
+* In the top right corner of the navigation bar, click your user name, and select User preferences.
+* Under the Access Tokens section, click New.
+* Enter a name for the token, and click Create.
+
+The generated API token appears. You must copy the token because it appears only once. After you click OK, you cannot retrieve this token again, you can only revoke it.
+
+``` yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: capi-user-credentials
+  namespace: default
+type: Opaque
+data:
+  username: ""
+  password: ""
+  refreshToken: "xxxxxxxxxxx"
+```
+
+## Create a cluster
+
+Edit the values file (at least the fields that aren't identified as optional), reference the secret containing the user's VCD credentials by name under `userContext > secretRef > secretName` and install the chart in the same namespace.

--- a/helm/cluster-cloud-director/Chart.yaml
+++ b/helm/cluster-cloud-director/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cluster-cloud-director
-version: 0.0.0
-appVersion: 0.5.1
+version: 0.0.2
+appVersion: 1.0.0-dev
 home: https://github.com/giantswarm/cluster-cloud-director
 sources:
 - https://github.com/giantswarm/cluster-cloud-director
@@ -19,4 +19,4 @@ maintainers:
   email: team-rocket@giantswarm.io
 restrictions:
   compatibleProviders:
-    - clouddirector # Check if this is correct
+    - vcd

--- a/helm/cluster-cloud-director/templates/cluster.yaml
+++ b/helm/cluster-cloud-director/templates/cluster.yaml
@@ -1,10 +1,11 @@
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    # cni: antrea # clusterResourceSet matching
 spec:
   clusterNetwork:
     pods:
@@ -12,19 +13,19 @@ spec:
       {{- range .Values.network.podsCidr }}
       - {{ . }}
       {{- end }}
-    serviceDomain: k8s.test
+    serviceDomain: {{ .Values.cluster.serviceDomain }}
     services:
       cidrBlocks:
       {{- range .Values.network.cidrBlocks }}
       - {{ . }}
       {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
     name: {{ include "resource.default.name" $ }}-control-plane
     namespace: {{ .Release.Namespace }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: VCDCluster
     name: {{ include "resource.default.name" $ }}
     namespace: {{ .Release.Namespace }}

--- a/helm/cluster-cloud-director/templates/kubeadmconfigtemplate.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmconfigtemplate.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: {{ include "resource.default.name" $ }}-md0

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
   name: {{ include "resource.default.name" $ }}-control-plane
@@ -16,13 +16,13 @@ spec:
         extraArgs:
           enable-hostpath-provisioner: "true"
       dns:
-        imageRepository: {{ .Values.kubeadm.dns.image }} # image repository to pull the DNS image from
-        imageTag: {{ .Values.kubeadm.dns.tag }} # DNS image tag associated with the TKGm OVA used. The values must be retrieved from the TKGm ova BOM. Refer to the github documentation for more details
+        imageRepository: {{ .Values.kubeadm.dns.image }}
+        imageTag: {{ .Values.kubeadm.dns.tag }}
       etcd:
         local:
-          imageRepository: {{ .Values.kubeadm.etcd.image }} # image repository to pull the etcd image from
-          imageTag: {{ .Values.kubeadm.etcd.tag }} # etcd image tag associated with the TKGm OVA used. The values must be retrieved from the TKGm ova BOM. Refer to the github documentation for more details
-      imageRepository: {{ .Values.kubeadm.imageRepository }} # image repository to use for the rest of kubernetes images
+          imageRepository: {{ .Values.kubeadm.etcd.image }}
+          imageTag: {{ .Values.kubeadm.etcd.tag }}
+      imageRepository: {{ .Values.kubeadm.imageRepository }}
     {{- if .Values.kubeadm.users }}
     {{- range .Values.kubeadm.users }}
     users:
@@ -47,7 +47,7 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: VCDMachineTemplate
       name: {{ include "resource.default.name" $ }}-control-plane
       namespace: {{ .Release.Namespace }}

--- a/helm/cluster-cloud-director/templates/machinedeployment.yaml
+++ b/helm/cluster-cloud-director/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: {{ include "resource.default.name" $ }}-md0
@@ -14,13 +14,13 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
           name: {{ include "resource.default.name" $ }}-md0
           namespace: {{ .Release.Namespace }}
       clusterName: {{ include "resource.default.name" $ }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VCDMachineTemplate
         name: {{ include "resource.default.name" $ }}-md0
         namespace: {{ .Release.Namespace }}

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDCluster
 metadata:
   name: {{ include "resource.default.name" $ }}
@@ -10,7 +10,23 @@ spec:
   org: {{ .Values.cloudDirector.org }}
   ovdc: {{ .Values.cloudDirector.ovdc }}
   ovdcNetwork: {{ .Values.cloudDirector.ovdcNetwork }}
+  parentUid: {{ .Values.cloudDirector.parentUid }}
+  useAsManagementCluster: {{ .Values.cloudDirector.useAsManagementCluster }}
   userContext:
-    username: {{ .Values.cloudDirector.userContext.username }}
-    password: {{ .Values.cloudDirector.userContext.password }}
-    refreshToken: {{ .Values.cloudDirector.userContext.refreshToken }}
+    {{- if .Values.userContext.secretRef.useSecretRef }}
+    secretRef:
+      name: {{ .Values.userContext.secretRef.secretName }}
+      namespace: {{ .Release.Namespace }}
+    {{- else }}
+    refreshToken: {{ .Values.userContext.refreshToken }}
+    username: {{ .Values.userContext.username }}
+    password: {{ .Values.userContext.password }}
+    {{- end }}
+  {{- if .Values.cloudDirector.storage.createStorageClass }}
+  defaultStorageClassOptions:
+    vcdStorageProfileName: {{ .Values.cloudDirector.storage.vcdStorageProfileName }}
+    k8sStorageClassName: {{ .Values.cloudDirector.storage.k8sStorageClassName }}
+    useDeleteReclaimPolicy: {{ .Values.cloudDirector.storage.useDeleteReclaimPolicy }}
+    fileSystem: {{ .Values.cloudDirector.storage.fileSystem }}
+  {{- end }}
+  rdeId: {{ .Values.cloudDirector.rdeId }}

--- a/helm/cluster-cloud-director/templates/vcdmachinetemplate.yaml
+++ b/helm/cluster-cloud-director/templates/vcdmachinetemplate.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDMachineTemplate
 metadata:
   name: {{ include "resource.default.name" $ }}-control-plane
@@ -10,9 +10,11 @@ spec:
     spec:
       catalog: {{ .Values.template.catalog }}
       template: {{ .Values.template.controlPlane.template }}
-      computePolicy: {{ .Values.template.controlPlane.computePolicy }}
+      sizingPolicy: {{ .Values.template.controlPlane.sizingPolicy }}
+      placementPolicy: {{ .Values.template.controlPlane.placementPolicy }}
+      storageProfile: {{ .Values.template.controlPlane.storageProfile }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDMachineTemplate
 metadata:
   name: {{ include "resource.default.name" $ }}-md0
@@ -24,4 +26,6 @@ spec:
     spec:
       catalog: {{ .Values.template.catalog }}
       template: {{ .Values.template.workerNode.template }}
-      computePolicy: {{ .Values.template.workerNode.computePolicy }}
+      sizingPolicy: {{ .Values.template.workerNode.sizingPolicy }}
+      placementPolicy: {{ .Values.template.workerNode.placementPolicy }}
+      storageProfile: {{ .Values.template.workerNode.storageProfile }}

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -1,48 +1,69 @@
 cluster:
-  kubernetesVersion: "" #  image defined at template.templateName
+  kubernetesVersion: ""
   name: "" # Cluster name; used as a base for names of all cluster resources.
   organization: "" # The organization which owns this cluster.
+  serviceDomain: k8s.test
 
 network:
-  podsCidr: # List of CIDR(s) to use for pod IPs.
+  podsCidr: # (Optional) List of CIDR(s) to use for pod IPs.
   - "100.96.0.0/11"
-  cidrBlocks:
-  - "100.64.0.0/13" # service CIDR for the cluster
+  cidrBlocks: # (Optional) service CIDR for the cluster.
+  - "100.64.0.0/13"
 
 cloudDirector:
-  site: "" # VCD endpoint with the format https://VCD_HOST. No trailing '/'
-  org: "" # VCD organization name where the cluster should be deployed
-  ovdc: "" # VCD virtual datacenter name where the cluster should be deployed
-  ovdcNetwork: "" # VCD virtual datacenter network to be used by the cluster
-  userContext:
-    username: "" # username of the VCD persona creating the cluster. Skipped if refreshToken is provided.
-    password: "" # password associated with the user creating the cluster
-    refreshToken: "" # refresh token of the client registered with VCD for creating clusters. username and password can be left blank if refresh token is provided
-  
-template:
-  catalog: "" # Catalog hosting the template, which will be used to deploy the control plane VMs
-  controlPlane: 
-    template: ""  # Name of the template to be used to create (or) upgrade the control plane nodes
-    computePolicy: "" # Sizing policy to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
-  workerNode: 
-    template: ""  # Name of the template to be used to create (or) upgrade the worker nodes
-    computePolicy: "" # Sizing policy to be used for the worker VMs (this must be pre-published on the chosen organization virtual datacenter). If no sizing policy should be used, use "".
+  site: "" # VCD endpoint with the format https://VCD_HOST. No trailing '/'.
+  org: "" # VCD organization name.
+  ovdc: "" # VCD virtual datacenter.
+  ovdcNetwork: "" # VCD virtual datacenter network to connect VMs.
+  storage:
+    createStorageClass: false # Set to true only if a default storage class needs to be created.
+    vcdStorageProfileName: "" # (Optional) VCD storage profile used to create the storage class.
+    k8sStorageClassName: "" # (Optional) storage class in kubernetes.
+    useDeleteReclaimPolicy: true # (Optional) true sets Reclaim policy to "Delete", false sets to "Retain".
+    fileSystem: "ext4" # (Optional) file system format for the persistent volumes created from the storage class.
+  rdeId: "" # (Optional) rdeId if it is already created. If empty, CAPVCD will create one for the cluster.
+  parentUid: "" # (Optional) Create the CAPVCD cluster from a specific management cluster associated with this UID.
+  useAsManagementCluster: false # (Optional) Displays as management cluster in the UI (cosmetic).
 
-kubeadm: # Provisioning options passed to kubeadm.
+userContext:
+  username: "" # (Optional) ignored if refreshToken is set.
+  password: "" # (Optional) ignored if refreshToken is set.
+  refreshToken: "" # (Optional) refreshToken (API token) - recommended.
+  secretRef:
+    # If set to false, you must specify username/password or refreshToken which will be in userContext of VCDCluster.
+    # Ignores secretName if set to false.
+    useSecretRef: true
+    # Name of the pre-existing secret containing the credentials of the VCD user.
+    secretName: ""
+
+template:
+  catalog: "" # VCD Catalog hosting the templates.
+  controlPlane: 
+    template: ""  # template used to create (or) upgrade control plane nodes.
+    sizingPolicy: "" # (Optional) Sizing policy for the control plane VMs (must be pre-published on the ovdc). "" for no sizing policy.
+    placementPolicy: "" # (Optional) Placement policy for control plane VMs (must be pre-published on the ovdc). "" for no placement Policy.
+    storageProfile: "" # (Optional) Storage profile for the control plane VMs (must be pre-published on the ovdc) "" for no Storage profile.
+  workerNode: 
+    template: ""  # template used to create (or) upgrade worker nodes.
+    sizingPolicy: "" # (Optional) Sizing policy for the worker VMs (must be pre-published on the ovdc). "" for no sizing policy.
+    placementPolicy: "" # (Optional) Placement policy for worker VMs (must be pre-published on the ovdc). "" for no placement Policy.
+    storageProfile: "" # (Optional) Storage profile for the worker VMs (must be pre-published on the ovdc) "" for no Storage profile.
+
+kubeadm:
   users:
     - name: ""
-      authorizedKeys: # All public SSH keys to assign to this user.
+      authorizedKeys: # (Optional) All public SSH keys to assign to this user.
         - ""
   dns:
-    image: projects.registry.vmware.com/tkg
-    tag: v1.7.0_vmware.12
+    image: projects.registry.vmware.com/tkg # (Optional) image repository to pull the DNS image from.
+    tag: v1.7.0_vmware.12 # (Optional) DNS image tag associated with the TKGm OVA used. The values must be retrieved from the TKGm ova BOM.
   etcd:
-    image: projects.registry.vmware.com/tkg
-    tag: v3.4.13_vmware.14
-  imageRepository: projects.registry.vmware.com/tkg
+    image: projects.registry.vmware.com/tkg # (Optional) image repository to pull the etcd image from.
+    tag: v3.4.13_vmware.14 # (Optional) etcd image tag associated with the TKGm OVA used. The values must be retrieved from the TKGm ova BOM.
+  imageRepository: projects.registry.vmware.com/tkg  # (Optional) image repository to use for the rest of kubernetes images.
 
 controlPlane:
-  replicas: 0 # Number of control plance instances to create. Must be an odd number.
+  replicas: 0 # Number of control plane instances to create (odd number).
 
 worker:
-  replicas: 0 # Number of worker instances to create.
+  replicas: 0 # Number of worker instanes to create.


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Adds support for secretRef. Currently a bug prevents from using it as the CPI is still installed during cloud-init and the credentials aren't carried out properly in the WC. When the CSI & CPI will be taken out of cloud-init, we won't have this issue as we will install them using our cloud-provider-cloud-director helm chart. Although this bug should be fixed shortly. In the meantime, the helm chart lets you choose whether to use secretRef or not. If not, creds or a token must be specified.
- Adds new parameters for new version of the CRDs available in main instead of 0.5.1.
- Adds a Readme.
