### PR TITLE
Fix unset control plane endpoint error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### FIXED
+
+- Fixed validating data error when controlPlaneEndpoint properties are not set.
+
 ## [0.1.1] - 2022-07-07
 
 ### FIXED

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -14,10 +14,12 @@ spec:
   {{- end }}
 
   {{- with .Values.cluster }}
-  # Not tested
-  controlPlaneEndpoint:
-    host: {{ .controlPlaneEndpoint.host }}
-    port: {{ .controlPlaneEndpoint.port }}
+  # Picks an IP automatically if unset
+  {{- if and .controlPlaneEndpoint.host .controlPlaneEndpoint.port }}
+    controlPlaneEndpoint:
+      host: {{ .controlPlaneEndpoint.host }}
+      port: {{ .controlPlaneEndpoint.port }}
+  {{- end }}
 
   # One arm is the old implementation with dnat rule + one arm LB
   loadBalancer:

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -16,9 +16,9 @@ spec:
   {{- with .Values.cluster }}
   # Picks an IP automatically if unset
   {{- if and .controlPlaneEndpoint.host .controlPlaneEndpoint.port }}
-    controlPlaneEndpoint:
-      host: {{ .controlPlaneEndpoint.host }}
-      port: {{ .controlPlaneEndpoint.port }}
+  controlPlaneEndpoint:
+    host: {{ .controlPlaneEndpoint.host }}
+    port: {{ .controlPlaneEndpoint.port }}
   {{- end }}
 
   # One arm is the old implementation with dnat rule + one arm LB


### PR DESCRIPTION
This PR:

- fixes a validating error when the controlPlaneEndpoint properties are set to empty values.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
