### PR TITLE
Add watching label for cluster-apps-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CHANGED
+
+- Added `cluster-apps-operator.giantswarm.io/watching: ""` label to `Cluster` CR.
+
 ## [0.1.2] - 2022-07-25
 
 ### FIXED

--- a/helm/cluster-cloud-director/templates/cluster.yaml
+++ b/helm/cluster-cloud-director/templates/cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}
   labels:
+    cluster-apps-operator.giantswarm.io/watching: ""
     {{- include "labels.common" . | nindent 4 }}
 spec:
   clusterNetwork:


### PR DESCRIPTION
We need this label. Otherwise, `cluster-apps-operator` ignores the cluster CR.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
