### PR TITLE
Move vipsubnet to vcdcluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CHANGED
+
+- Moved vipSubnet from `cluster-api-provider-cloud-director-app` to `cluster-cloud-director`
+
 ## [0.1.3] - 2022-08-03
 
 ### CHANGED

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ data:
 
 Edit the values file (at least the fields that aren't identified as optional), reference the secret containing the user's VCD credentials by name under `userContext > secretRef > secretName` and install the chart in the same namespace.
 
+In the UI `vipSubnet` is the field in `Networking > Edge Gateway > IP Management > IP Allocations > Allocated IPs > IP Block`. For instance in Ikoula:
+
+``` yaml
+vcd:
+  vipSubnet: "178.170.32.1/24"
+```
+
 Example of a values.yaml file for Cloud provider Ikoula with minimum input (making use of default values):
 
 ```yaml
@@ -42,6 +49,8 @@ cluster:
   kubernetesVersion: "v1.22.5+vmware.1"
   name: "xav"
   organization: "giantswarm"
+  loadBalancer:
+    vipSubnet: ""
 
 cloudDirector:
   site: "https://vmware.ikoula.com"

--- a/README.md
+++ b/README.md
@@ -35,12 +35,7 @@ data:
 
 Edit the values file (at least the fields that aren't identified as optional), reference the secret containing the user's VCD credentials by name under `userContext > secretRef > secretName` and install the chart in the same namespace.
 
-In the UI `vipSubnet` is the field in `Networking > Edge Gateway > IP Management > IP Allocations > Allocated IPs > IP Block`. For instance in Ikoula:
-
-``` yaml
-vcd:
-  vipSubnet: "178.170.32.1/24"
-```
+In the UI `vipSubnet` is the field in `Networking > Edge Gateway > IP Management > IP Allocations > Allocated IPs > IP Block`. For instance in Ikoula `178.170.32.1/24`
 
 Example of a values.yaml file for Cloud provider Ikoula with minimum input (making use of default values):
 
@@ -50,7 +45,7 @@ cluster:
   name: "xav"
   organization: "giantswarm"
   loadBalancer:
-    vipSubnet: ""
+    vipSubnet: "w.x.y.z/aa"
 
 cloudDirector:
   site: "https://vmware.ikoula.com"

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -23,7 +23,7 @@ spec:
 
   # One arm is the old implementation with dnat rule + one arm LB
   loadBalancer:
-    useOneArm: {{ .loadBalancer.useOneArm }}
+    vipSubnet: {{ .loadBalancer.vipSubnet }}
 
   # Persistent storage with Named disks
   {{- with .defaultStorageClass }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -59,8 +59,8 @@
                 "loadBalancer": {
                     "type": "object",
                     "properties": {
-                        "useOneArm": {
-                            "type": "boolean"
+                        "vipSubnet": {
+                            "type": "string"
                         }
                     }
                 },

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -2,6 +2,8 @@ cluster:
   kubernetesVersion: ""
   name: ""  # Cluster name; used as a base for names of all cluster resources.
   organization: ""  # The organization which owns this cluster.
+  loadBalancer:
+    vipSubnet: ""  # Virtual IP CIDR for the external network
   ######### All the cluster fields below can be left as default #########
   serviceDomain: k8s.test
   network:
@@ -22,8 +24,6 @@ cluster:
     httpProxy: ""
     httpsProxy: ""
     noProxy: ""  # Bypass the proxy for specific hosts - cluster IP range for instance.
-  loadBalancer:
-    useOneArm: false  # https://github.com/vmware/cluster-api-provider-cloud-director/blob/9496da684e229ef0947ab43e3d67ca242c2ff632/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go#L1366-L1370
   rdeId: ""  # (Optional) rdeId if it is already created. If empty, CAPVCD will create one for the cluster.
   parentUid: ""  # (Optional) Create the CAPVCD cluster from a specific management cluster associated with this UID.
   useAsManagementCluster: false  # (Optional) Displays as management cluster in the UI (cosmetic).


### PR DESCRIPTION
This PR:

- Moves vipSubnet from `cluster-api-provider-cloud-director-app` to `cluster-cloud-director` towards https://github.com/giantswarm/cluster-api-provider-cloud-director-app/pull/13

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
