### PR TITLE
Adds skip rde,align values file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CHANGED
+
+- Align values file structure with other providers.
+- Removed cluster name from values file in favour of the chart's name.
+
 ### Added
 
 - Allow setting etcd image repository and tag.
 - Set the default etcd version to 3.5.4 (kubeadm default is 3.5.0 which is not
   recommended in production).
 - Set the default etcd image to retagged Giant Swarm one.
+- Added `skipRDE` switch which include `RdeID` to `VCDCluster` when __NO_RDE__ is used to fix `clusterctl move`.
 
 ## [0.2.0] - 2022-08-09
 

--- a/README.md
+++ b/README.md
@@ -37,48 +37,54 @@ Edit the values file (at least the fields that aren't identified as optional), r
 
 In the UI `vipSubnet` is the field in `Networking > Edge Gateway > IP Management > IP Allocations > Allocated IPs > IP Block`. For instance in Ikoula `178.170.32.1/24`
 
+Set skipRDE if the [VCD API schema extension](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/docs/VCD_SETUP.md#register-cluster-api-schema) wasn't registered by the cloud provider.
+
 Example of a values.yaml file for Cloud provider Ikoula with minimum input (making use of default values):
 
 ```yaml
-cluster:
-  kubernetesVersion: "v1.22.5+vmware.1"
-  name: "xav"
-  organization: "giantswarm"
-  loadBalancer:
-    vipSubnet: "w.x.y.z/aa"
+baseDomain: k8s.test
+clusterDescription: "test cluster Xavier"
+kubernetesVersion: "v1.22.5+vmware.1"
+organization: "giantswarm"
 
 cloudDirector:
   site: "https://vmware.ikoula.com"
-  org: "xxxx"
-  ovdc: "xxxx"
-  ovdcNetwork: "xxxx"
+  org: "xxx"
+  ovdc: "xxx"
+  ovdcNetwork: "xxx"
 
-userContext:
-  secretRef:
-    useSecretRef: true
-    secretName: "xav-secret"
+cluster:
+  skipRDE: true
 
 controlPlane:
   replicas: 1
   catalog: "giantswarm"
   template: "ubuntu-2004-kube-v1.22.5"
-  sizingPolicy: ""
-  placementPolicy: ""
-  storageProfile: ""
+  sizingPolicy: "m1.medium"
+
+network:
+  loadBalancer:
+    vipSubnet: "178.170.32.1/24"
 
 nodeClasses:
-  - name: worker
+  - name: "worker"
     catalog: "giantswarm"
     template: "ubuntu-2004-kube-v1.22.5"
-    sizingPolicy: ""
-    placementPolicy: ""
-    storageProfile: ""
+    sizingPolicy: "m1.medium"
 
 nodePools:
-  - class: worker
-    name: worker
-    replicas: 2
-  - class: worker
-    name: lazy
-    replicas: 1
+  - class: "worker"
+    name: "worker"
+    replicas: 3
+
+ssh:
+  users:
+    - name: "root"
+      authorizedKeys:
+        - "xxx"
+
+userContext:
+  refreshToken: "xxxx"
+  secretRef:
+    useSecretRef: false
 ```

--- a/helm/cluster-cloud-director/Chart.yaml
+++ b/helm/cluster-cloud-director/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
   email: team-rocket@giantswarm.io
 restrictions:
   compatibleProviders:
-    - vcd
+    - cloud-director

--- a/helm/cluster-cloud-director/ci/ci-values.yaml
+++ b/helm/cluster-cloud-director/ci/ci-values.yaml
@@ -1,78 +1,45 @@
-cluster:
-  kubernetesVersion: "v1.22.5+vmware.1"
-  name: "testcluster"
-  organization: "giantswarmtestorg"
-  serviceDomain: k8s.test
-  network:
-    podsCidrBlocks:
-    - "10.10.10.10/11"
-    servicesCidrBlocks:
-    - "11.10.10.10/13"
-  controlPlaneEndpoint:
-    host: "1.2.3.4"
-    port: "6443"
-  defaultStorageClass:
-    enable: false
-    vcdStorageProfileName: ""
-    k8sStorageClassName: ""
-    useDeleteReclaimPolicy: true
-    fileSystem: "ext4"
-  proxyConfig:
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""
-  loadBalancer:
-    useOneArm: false
-  rdeId: ""
-  parentUid: ""
-  useAsManagementCluster: false
+baseDomain: k8s.test
+clusterDescription: "test cluster Xavier"
+kubernetesVersion: "v1.22.5+vmware.1"
+organization: "giantswarm"
 
 cloudDirector:
-  site: "https://test.vcd.com"
-  org: "testorg"
-  ovdc: "testovdc"
-  ovdcNetwork: "test-network"
+  site: "https://vmware.ikoula.com"
+  org: "xxx"
+  ovdc: "xxx"
+  ovdcNetwork: "xxx"
 
-userContext:
-  username: ""
-  password: ""
-  refreshToken: ""
-  secretRef:
-    useSecretRef: true
-    secretName: "test-secret"
-
-kubeadm:
-  users:
-    - name: "root"
-      authorizedKeys:
-        - "a fake secret"
-  dns:
-    image:
-      repository: projects.registry.vmware.com/tkg
-      tag: v1.7.0_vmware.12
-  image:
-    repository: projects.registry.vmware.com/tkg
+cluster:
+  skipRDE: true
 
 controlPlane:
   replicas: 1
-  catalog: "a test catalog"
-  template: "a test template"
-  sizingPolicy: ""
-  placementPolicy: ""
-  storageProfile: ""
+  catalog: "giantswarm"
+  template: "ubuntu-2004-kube-v1.22.5"
+  sizingPolicy: "m1.medium"
+
+network:
+  loadBalancer:
+    vipSubnet: "178.170.32.1/24"
 
 nodeClasses:
-  - name: worker
-    catalog: "a test catalog"
-    template: "a test template"
-    sizingPolicy: ""
-    placementPolicy: ""
-    storageProfile: ""
+  - name: "worker"
+    catalog: "giantswarm"
+    template: "ubuntu-2004-kube-v1.22.5"
+    sizingPolicy: "m1.medium"
 
 nodePools:
-  - class: worker
-    name: worker
-    replicas: 9000
-  - class: worker
-    name: lazy
-    replicas: 1
+  - class: "worker"
+    name: "worker"
+    replicas: 3
+
+ssh:
+  users:
+    - name: "root"
+      authorizedKeys:
+        - "xxx"
+
+userContext:
+  refreshToken: "xxxx"
+  secretRef:
+    useSecretRef: false

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -28,7 +28,7 @@ app: {{ include "name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
-giantswarm.io/organization: {{ .Values.cluster.organization | quote }}
+giantswarm.io/organization: {{ .Values.organization | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
@@ -46,7 +46,7 @@ app.kubernetes.io/version: {{ $.Chart.Version | quote }}
 Create a prefix for all resource names.
 */}}
 {{- define "resource.default.name" -}}
-{{ .Values.cluster.name }}
+{{ .Release.Name }}
 {{- end -}}
 
 {{- define "kubeletExtraArgs" -}}
@@ -61,7 +61,7 @@ See https://github.com/kubernetes-sigs/cluster-api/pull/5027/files
 */}}
 {{- define "kubeAdmConfigTemplateRevision" -}}
 {{- $inputs := (dict
-  "users" .Values.kubeadm.users
+  "users" .Values.ssh.users
   "kubeletExtraArgs" (include "kubeletExtraArgs" .) ) }}
 {{- mustToJson $inputs | toString | quote | sha1sum | trunc 8 }}
 {{- end -}}

--- a/helm/cluster-cloud-director/templates/cluster.yaml
+++ b/helm/cluster-cloud-director/templates/cluster.yaml
@@ -3,6 +3,8 @@ kind: Cluster
 metadata:
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
     {{- include "labels.common" . | nindent 4 }}
@@ -10,13 +12,13 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-      {{- range .Values.cluster.network.podsCidrBlocks }}
+      {{- range .Values.network.podsCidrBlocks }}
       - {{ . }}
       {{- end }}
-    serviceDomain: {{ .Values.cluster.serviceDomain }}
+    serviceDomain: {{ .Values.baseDomain }}
     services:
       cidrBlocks:
-      {{- range .Values.cluster.network.servicesCidrBlocks }}
+      {{- range .Values.network.servicesCidrBlocks }}
       - {{ . }}
       {{- end }}
   controlPlaneRef:

--- a/helm/cluster-cloud-director/templates/kubeadmconfigtemplate.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmconfigtemplate.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   template:
     spec:
-      {{- if $.Values.kubeadm.users }}
-      {{- range $.Values.kubeadm.users }}
+      {{- if $.Values.ssh.users }}
+      {{- range $.Values.ssh.users }}
       users:
       - name: {{ .name }}
         sshAuthorizedKeys:

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -12,20 +12,20 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
-        - "api.{{ include "resource.default.name" $ }}.{{ .Values.cluster.serviceDomain }}"
+        - "api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomain }}"
       controllerManager:
         extraArgs:
           enable-hostpath-provisioner: "true"
       dns:
-        imageRepository: {{ .Values.kubeadm.dns.image.repository }}
-        imageTag: {{ .Values.kubeadm.dns.image.tag }}
+        imageRepository: {{ .Values.controlPlane.dns.imageRepository }}
+        imageTag: {{ .Values.controlPlane.dns.imageTag }}
       etcd:
         local:
           imageRepository: {{ .Values.controlPlane.etcd.imageRepository }}
           imageTag: {{ .Values.controlPlane.etcd.imageTag }}
-      imageRepository: {{ .Values.kubeadm.image.repository }}
-    {{- if .Values.kubeadm.users }}
-    {{- range .Values.kubeadm.users }}
+      imageRepository: {{ .Values.controlPlane.image.repository }}
+    {{- if .Values.ssh.users }}
+    {{- range .Values.ssh.users }}
     users:
     - name: {{ .name }}
       sshAuthorizedKeys: 
@@ -53,4 +53,4 @@ spec:
       name: {{ include "resource.default.name" . }}-control-plane-{{ include "mtRevisionOfControlPlane" $ }}
       namespace: {{ .Release.Namespace }}
   replicas: {{ .Values.controlPlane.replicas }}
-  version: {{ .Values.cluster.kubernetesVersion }}
+  version: {{ .Values.kubernetesVersion }}

--- a/helm/cluster-cloud-director/templates/machinedeployment.yaml
+++ b/helm/cluster-cloud-director/templates/machinedeployment.yaml
@@ -29,5 +29,5 @@ spec:
         kind: VCDMachineTemplate
         name: {{ include "resource.default.name" $ }}-{{ .class }}-{{ include "mtRevisionByClass" (merge . $) }}
         namespace: {{ $.Release.Namespace }}
-      version: {{ $.Values.cluster.kubernetesVersion }}
+      version: {{ $.Values.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -13,7 +13,7 @@ spec:
   ovdcNetwork: {{ .ovdcNetwork }}
   {{- end }}
 
-  {{- with .Values.cluster }}
+  {{- with .Values.network }}
   # Picks an IP automatically if unset
   {{- if and .controlPlaneEndpoint.host .controlPlaneEndpoint.port }}
   controlPlaneEndpoint:
@@ -21,12 +21,19 @@ spec:
     port: {{ .controlPlaneEndpoint.port }}
   {{- end }}
 
-  # One arm is the old implementation with dnat rule + one arm LB
+  # One arm was the old implementation with dnat rule + one arm LB
   loadBalancer:
     vipSubnet: {{ .loadBalancer.vipSubnet }}
 
+  # Proxy settings
+  proxyConfig:
+    httpProxy: {{ .proxyConfig.httpProxy }}
+    httpsProxy: {{ .proxyConfig.httpsProxy }}
+    noProxy: {{ .proxyConfig.noProxy }}
+  {{- end }}
+
   # Persistent storage with Named disks
-  {{- with .defaultStorageClass }}
+  {{- with .Values.defaultStorageClass }}
   {{- if .enable }}
   defaultStorageClassOptions:
     vcdStorageProfileName: {{ .vcdStorageProfileName }}
@@ -36,21 +43,17 @@ spec:
   {{- end }}
   {{- end }}
 
-  # Proxy settings
-  proxyConfig:
-    httpProxy: {{ .proxyConfig.httpProxy }}
-    httpsProxy: {{ .proxyConfig.httpsProxy }}
-    noProxy: {{ .proxyConfig.noProxy }}
-
   # Not tested - not sure how
+  {{- with .Values.cluster }}
   rdeId: {{ .rdeId }}
   parentUid: {{ .parentUid }}
   useAsManagementCluster: {{ .useAsManagementCluster }}
+  skipRDE: {{ .skipRDE }}
   {{- end }}
 
   # Authentication  
   userContext:
-    {{- if .Values.userContext.secretRef.useSecretRef }}  # I don't trust the upstream prioritization.
+    {{- if .Values.userContext.secretRef.useSecretRef }}
     secretRef:
       name: {{ .Values.userContext.secretRef.secretName }}
       namespace: {{ .Release.Namespace }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "baseDomain": {
+            "type": "string"
+        },
         "cloudDirector": {
             "type": "object",
             "properties": {
@@ -22,104 +25,39 @@
         "cluster": {
             "type": "object",
             "properties": {
-                "controlPlaneEndpoint": {
-                    "type": "object",
-                    "properties": {
-                        "host": {
-                            "type": "string"
-                        },
-                        "port": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "defaultStorageClass": {
-                    "type": "object",
-                    "properties": {
-                        "enable": {
-                            "type": "boolean"
-                        },
-                        "fileSystem": {
-                            "type": "string"
-                        },
-                        "k8sStorageClassName": {
-                            "type": "string"
-                        },
-                        "useDeleteReclaimPolicy": {
-                            "type": "boolean"
-                        },
-                        "vcdStorageProfileName": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "kubernetesVersion": {
-                    "type": "string"
-                },
-                "loadBalancer": {
-                    "type": "object",
-                    "properties": {
-                        "vipSubnet": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "name": {
-                    "type": "string"
-                },
-                "network": {
-                    "type": "object",
-                    "properties": {
-                        "podsCidrBlocks": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "servicesCidrBlocks": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "organization": {
-                    "type": "string"
-                },
                 "parentUid": {
                     "type": "string"
-                },
-                "proxyConfig": {
-                    "type": "object",
-                    "properties": {
-                        "httpProxy": {
-                            "type": "string"
-                        },
-                        "httpsProxy": {
-                            "type": "string"
-                        },
-                        "noProxy": {
-                            "type": "string"
-                        }
-                    }
                 },
                 "rdeId": {
                     "type": "string"
                 },
-                "serviceDomain": {
-                    "type": "string"
-                },
                 "useAsManagementCluster": {
+                    "type": "boolean"
+                },
+                "skipRDE": {
                     "type": "boolean"
                 }
             }
+        },
+        "clusterDescription": {
+            "type": "string"
         },
         "controlPlane": {
             "type": "object",
             "properties": {
                 "catalog": {
                     "type": "string"
+                },
+                "dns": {
+                    "type": "object",
+                    "properties": {
+                        "imageRepository": {
+                            "type": "string"
+                        },
+                        "imageTag": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "etcd": {
                     "type": "object",
@@ -128,6 +66,14 @@
                             "type": "string"
                         },
                         "imageTag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
                             "type": "string"
                         }
                     }
@@ -149,48 +95,75 @@
                 }
             }
         },
-        "kubeadm": {
+        "defaultStorageClass": {
             "type": "object",
             "properties": {
-                "dns": {
-                    "type": "object",
-                    "properties": {
-                        "image": {
-                            "type": "object",
-                            "properties": {
-                                "repository": {
-                                    "type": "string"
-                                },
-                                "tag": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                "enable": {
+                    "type": "boolean"
                 },
-                "image": {
+                "fileSystem": {
+                    "type": "string"
+                },
+                "k8sStorageClassName": {
+                    "type": "string"
+                },
+                "useDeleteReclaimPolicy": {
+                    "type": "boolean"
+                },
+                "vcdStorageProfileName": {
+                    "type": "string"
+                }
+            }
+        },
+        "kubernetesVersion": {
+            "type": "string"
+        },
+        "network": {
+            "type": "object",
+            "properties": {
+                "controlPlaneEndpoint": {
                     "type": "object",
                     "properties": {
-                        "repository": {
+                        "host": {
+                            "type": "string"
+                        },
+                        "port": {
                             "type": "string"
                         }
                     }
                 },
-                "users": {
+                "loadBalancer": {
+                    "type": "object",
+                    "properties": {
+                        "vipSubnet": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "podsCidrBlocks": {
                     "type": "array",
                     "items": {
-                        "type": "object",
-                        "properties": {
-                            "authorizedKeys": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "name": {
-                                "type": "string"
-                            }
+                        "type": "string"
+                    }
+                },
+                "proxyConfig": {
+                    "type": "object",
+                    "properties": {
+                        "httpProxy": {
+                            "type": "string"
+                        },
+                        "httpsProxy": {
+                            "type": "string"
+                        },
+                        "noProxy": {
+                            "type": "string"
                         }
+                    }
+                },
+                "servicesCidrBlocks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }
@@ -248,6 +221,31 @@
             },
             "minItems": 1,
             "type": "array"
+        },
+	"organization": {
+            "type": "string"
+        },
+        "ssh": {
+            "type": "object",
+            "properties": {
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "authorizedKeys": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
         },
         "userContext": {
             "type": "object",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -20,7 +20,13 @@
                 "site": {
                     "type": "string"
                 }
-            }
+            },
+            "required": [
+                "org",
+                "ovdc",
+                "ovdcNetwork",
+                "site"
+            ]
         },
         "cluster": {
             "type": "object",
@@ -44,6 +50,13 @@
         },
         "controlPlane": {
             "type": "object",
+            "required": [
+                "catalog",
+                "template",
+                "replicas",
+                "dns",
+                "etcd"
+            ],
             "properties": {
                 "catalog": {
                     "type": "string"
@@ -166,7 +179,12 @@
                         "type": "string"
                     }
                 }
-            }
+            },
+            "required": [
+                "loadBalancer",
+                "podsCidrBlocks",
+                "servicesCidrBlocks"
+            ]
         },
         "nodeClasses": {
             "items": {

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -1,32 +1,8 @@
-cluster:
-  kubernetesVersion: ""
-  name: ""  # Cluster name; used as a base for names of all cluster resources.
-  organization: ""  # The organization which owns this cluster.
-  loadBalancer:
-    vipSubnet: ""  # Virtual IP CIDR for the external network
-  ######### All the cluster fields below can be left as default #########
-  serviceDomain: k8s.test
-  network:
-    podsCidrBlocks:  # (Optional) List of CIDR(s) to use for pod IPs.
-    - "100.96.0.0/11"
-    servicesCidrBlocks:  # (Optional) service CIDR for the cluster.
-    - "100.64.0.0/13"
-  controlPlaneEndpoint:
-    host: ""  # [string] Manually select an IP for LB
-    port: ""  # [int] Port to use
-  defaultStorageClass:
-    enable: false  # Set to true only if a default storage class needs to be created.
-    vcdStorageProfileName: ""  # (Optional) VCD storage profile to create the storage class.
-    k8sStorageClassName: ""  # (Optional) Associated storage class in kubernetes.
-    useDeleteReclaimPolicy: true  # (Optional) true sets Reclaim policy to "Delete", false sets to "Retain".
-    fileSystem: "ext4"  # (Optional) file system for the persistent volumes from the storage class.
-  proxyConfig:  # Defines HTTP proxy environment variables
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""  # Bypass the proxy for specific hosts - cluster IP range for instance.
-  rdeId: ""  # (Optional) rdeId if it is already created. If empty, CAPVCD will create one for the cluster.
-  parentUid: ""  # (Optional) Create the CAPVCD cluster from a specific management cluster associated with this UID.
-  useAsManagementCluster: false  # (Optional) Displays as management cluster in the UI (cosmetic).
+baseDomain: k8s.test
+clusterDescription: ""  # Cluster description used in metadata.
+# clusterName: ""  # Name of cluster. Used as base name for all cluster resources in the management cluster.
+kubernetesVersion: ""
+organization: ""  # The organization which owns this cluster.
 
 cloudDirector:
   site: ""  # VCD endpoint with the format https://VCD_HOST. No trailing '/'.
@@ -34,39 +10,49 @@ cloudDirector:
   ovdc: ""  # VCD virtual datacenter.
   ovdcNetwork: ""  # VCD network to connect VMs.
 
-userContext:
-  username: ""  # (Optional) ignored if refreshToken is set.
-  password: ""  # (Optional) ignored if refreshToken is set.
-  refreshToken: ""  # (Optional) refreshToken (API token) - recommended.
-  secretRef:
-    # If set to false, ignores secretName and you must specify username/password or refreshToken which will be in userContext of VCDCluster.
-    # If set to true, ignores credentials, you must specify secretName and have a pre-existing secret <= recommended method.
-    useSecretRef: true
-    # Name of the pre-existing secret containing the credentials of the VCD user.
-    secretName: ""
-
-kubeadm:
-  users:
-    - name: ""
-      authorizedKeys:  # (Optional) All public SSH keys to assign to this user.
-        - ""
-  dns:
-    image:
-      repository: projects.registry.vmware.com/tkg  # (Optional) image repository to pull the DNS image from.
-      tag: v1.7.0_vmware.12  # (Optional) DNS image tag associated with the TKGm OVA used. The values must be retrieved from the TKGm ova BOM.
-  image:
-    repository: projects.registry.vmware.com/tkg  # (Optional) image repository to use for the rest of kubernetes images.
+cluster:
+  rdeId: ""  # (Optional) If empty, CAPVCD will create one.
+  parentUid: ""  # (Optional) Create the CAPVCD cluster from a specific management cluster associated with this UID.
+  useAsManagementCluster: false  # (Optional) Displays as management cluster in the UI (cosmetic).
+  skipRDE: false
 
 controlPlane:  # Must match nodeClasses' fields except "name" and must contain "replicas".
   replicas: 0  # Number of control plane instances to create (odd number).
-  catalog: ""
+  catalog: ""  # VCD catalog where the template is stored.
   template: ""  # template used to create (or) upgrade control plane nodes.
-  sizingPolicy: ""  # (Optional) Sizing policy for the control plane VMs (must be pre-published on the ovdc). "" for no sizing policy.
-  placementPolicy: ""  # (Optional) Placement policy for control plane VMs (must be pre-published on the ovdc). "" for no placement Policy.
-  storageProfile: ""  # (Optional) Storage profile for the control plane VMs (must be pre-published on the ovdc) "" for no Storage profile.
+  sizingPolicy: ""  # Sizing policy for the control plane VMs. "" for no sizing policy.
+  placementPolicy: ""  # Placement policy for control plane VMs. "" for no placement Policy.
+  storageProfile: ""  # Storage profile for the control plane VMs. "" for no Storage profile.
   etcd:
     imageRepository: "giantswarm"
     imageTag: 3.5.4-0-k8s
+  dns: 
+    imageRepository: projects.registry.vmware.com/tkg
+    imageTag: v1.7.0_vmware.12
+  image:
+    repository: projects.registry.vmware.com/tkg
+
+defaultStorageClass:
+  enable: false  # Set to true to create a default storage class.
+  vcdStorageProfileName: ""  # VCD storage profile to create the storage class.
+  k8sStorageClassName: ""  # Associated storage class in kubernetes.
+  useDeleteReclaimPolicy: true  # true sets Reclaim policy to "Delete", false sets it to "Retain".
+  fileSystem: "ext4"  # file system for the persistent volumes.
+
+network:
+  podsCidrBlocks:
+  - "100.96.0.0/11"
+  servicesCidrBlocks:
+  - "100.64.0.0/13"
+  controlPlaneEndpoint:
+    host: ""  # [string] Manually select an IP for kube API. "" for auto selection from pool.
+    port: ""  # [int] Port to use. "" defaults to 6443.
+  loadBalancer:
+    vipSubnet: ""  # Virtual IP CIDR for the external network.
+  proxyConfig:  # (Optional) Defines HTTP proxy environment variables.
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""  # Bypass the proxy for specific hosts - cluster IP range for instance.
 
 nodeClasses: []
   # - name: worker  # Name of the class to use in nodePool and machinetemplate name.
@@ -80,3 +66,19 @@ nodePools: []
   # - class: worker
   #   name: worker  # Name of nodepool used in machinedeple name
   #   replicas: 2
+
+ssh:
+  users:  # (Optional) public SSH keys/users to access the nodes.
+    - name: ""
+      authorizedKeys:
+        - ""
+
+userContext:
+  username: ""  # (Optional) ignored if refreshToken is set.
+  password: ""  # (Optional) ignored if refreshToken is set.
+  refreshToken: ""  # (Optional) refreshToken (API token).
+  secretRef:
+    # If set to false, ignores secretName and you must specify username/password or refreshToken which will be in userContext of VCDCluster.
+    # If set to true, ignores username/password/refreshToken, you must specify secretName and have a pre-existing secret <= recommended method.
+    useSecretRef: true
+    secretName: ""  # Name of the pre-existing secret containing the credentials of the VCD user.

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -14,7 +14,7 @@ cluster:
   rdeId: ""  # (Optional) If empty, CAPVCD will create one.
   parentUid: ""  # (Optional) Create the CAPVCD cluster from a specific management cluster associated with this UID.
   useAsManagementCluster: false  # (Optional) Displays as management cluster in the UI (cosmetic).
-  skipRDE: false
+  skipRDE: false  # Set to "true" if API schema extension isn't registered.
 
 controlPlane:  # Must match nodeClasses' fields except "name" and must contain "replicas".
   replicas: 0  # Number of control plane instances to create (odd number).


### PR DESCRIPTION
This PR:

- Align values file with openstack.
- Removes cluster name from values and uses release name instead.
- Adds skipRDE feature to fix `clusterctl move` when API schema is not registered.

### Testing

Tested helm chart in Ikoula with [CAPVCD](https://github.com/giantswarm/cluster-api-provider-cloud-director-app/pull/17).

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
