### PR TITLE
Set revisionHistoryLimit as 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CHANGED
 
-- Set `revisionHistoryLimit` in `VCDMachineDeployment` as `0` for `deletion-blocker-operator`.
+- Set `revisionHistoryLimit` in `MachineDeployment` as `0` for `deletion-blocker-operator`.
 
 ## [0.2.2] - 2022-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### CHANGED
+
+- Set `revisionHistoryLimit` in `VCDMachineDeployment` as `0` for `deletion-blocker-operator`.
+
 ## [0.2.2] - 2022-08-18
 
 ### CHANGED

--- a/helm/cluster-cloud-director/templates/machinedeployment.yaml
+++ b/helm/cluster-cloud-director/templates/machinedeployment.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   clusterName: {{ include "resource.default.name" $ }}
   replicas: {{ .replicas }}
+  revisionHistoryLimit: 0
   selector:
     matchLabels: null
   template:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1193

See https://github.com/giantswarm/cluster-openstack/blob/main/helm/cluster-openstack/templates/machine_deployment.yaml#L12

deletion-blocker-operator observes `MachineSet` objects and it allows deletion of `VCDMachineTemplate` when there is no `MachineSet` that has a reference to that `VCDMachineTemplate`. By setting `revisionHistoryLimit` as `0`, we ask `machine-deployment-controller` to delete old `MachineSet` just after completing the updates.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
