### PR TITLE
remove default storage class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CHANGED
 
 - Set `revisionHistoryLimit` in `MachineDeployment` as `0` for `deletion-blocker-operator`.
+- Removed `defaultStorageClass` since it was moved to the cloud provider.
 
 ## [0.2.2] - 2022-08-18
 

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -32,17 +32,6 @@ spec:
     noProxy: {{ .proxyConfig.noProxy }}
   {{- end }}
 
-  # Persistent storage with Named disks
-  {{- with .Values.defaultStorageClass }}
-  {{- if .enable }}
-  defaultStorageClassOptions:
-    vcdStorageProfileName: {{ .vcdStorageProfileName }}
-    k8sStorageClassName: {{ .k8sStorageClassName }}
-    useDeleteReclaimPolicy: {{ .useDeleteReclaimPolicy }}
-    fileSystem: {{ .fileSystem }}
-  {{- end }}
-  {{- end }}
-
   # Not tested - not sure how
   {{- with .Values.cluster }}
   rdeId: {{ .rdeId }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -108,26 +108,6 @@
                 }
             }
         },
-        "defaultStorageClass": {
-            "type": "object",
-            "properties": {
-                "enable": {
-                    "type": "boolean"
-                },
-                "fileSystem": {
-                    "type": "string"
-                },
-                "k8sStorageClassName": {
-                    "type": "string"
-                },
-                "useDeleteReclaimPolicy": {
-                    "type": "boolean"
-                },
-                "vcdStorageProfileName": {
-                    "type": "string"
-                }
-            }
-        },
         "kubernetesVersion": {
             "type": "string"
         },

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -33,13 +33,6 @@ controlPlane:  # Must match nodeClasses' fields except "name" and must contain "
   image:
     repository: projects.registry.vmware.com/tkg
 
-defaultStorageClass:
-  enable: false  # Set to true to create a default storage class.
-  vcdStorageProfileName: ""  # VCD storage profile to create the storage class.
-  k8sStorageClassName: ""  # Associated storage class in kubernetes.
-  useDeleteReclaimPolicy: true  # true sets Reclaim policy to "Delete", false sets it to "Retain".
-  fileSystem: "ext4"  # file system for the persistent volumes.
-
 network:
   podsCidrBlocks:
   - "100.96.0.0/11"


### PR DESCRIPTION
This PR:

- removes default storage class from the cluster chart since it was removed from cloud init and is now installed as part of the cloud provider chart.
### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
