### PR TITLE
Move specs of immutable templates to helpers.tpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add servicePriority label on cluster object in the chart.
+- Move specs to helpers.tpl to have single source of truth.
 
 ### CHANGED
 

--- a/helm/cluster-cloud-director/templates/kubeadmconfigtemplate.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmconfigtemplate.yaml
@@ -3,27 +3,12 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: {{ include "resource.default.name" $ }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" $ }}
+  name: {{ include "resource.default.name" $ }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" (merge (dict "pool" .) $) }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
   template:
     spec:
-      {{- if $.Values.ssh.users }}
-      {{- range $.Values.ssh.users }}
-      users:
-      - name: {{ .name }}
-        sshAuthorizedKeys:
-        {{- range .authorizedKeys }}
-        - {{ . }}
-        {{- end }}
-      {{- end }}
-      {{- end }}
-      joinConfiguration:
-        nodeRegistration:
-          criSocket: /run/containerd/containerd.sock
-          kubeletExtraArgs:
-            {{- include "kubeletExtraArgs" . | nindent  12}}
-            node-labels: "giantswarm.io/node-pool={{ .name }}"
+      {{- include "kubeAdmConfigTemplateSpec" (merge (dict "pool" .) $) | nindent 6 -}}
 {{- end }}

--- a/helm/cluster-cloud-director/templates/machinedeployment.yaml
+++ b/helm/cluster-cloud-director/templates/machinedeployment.yaml
@@ -22,7 +22,7 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
-          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" $ }}
+          name: {{ include "resource.default.name" $ }}-{{ .name }}-{{- include "kubeAdmConfigTemplateRevision" (merge (dict "pool" .) $) }}
           namespace: {{ $.Release.Namespace }}
       clusterName: {{ include "resource.default.name" $ }}
       infrastructureRef:

--- a/helm/cluster-cloud-director/templates/vcdmachinetemplate.yaml
+++ b/helm/cluster-cloud-director/templates/vcdmachinetemplate.yaml
@@ -10,9 +10,5 @@ metadata:
 spec:
   template:
     spec:
-      catalog: {{ .catalog }}
-      template: {{ .template }}
-      sizingPolicy: {{ .sizingPolicy }}
-      placementPolicy: {{ .placementPolicy }}
-      storageProfile: {{ .storageProfile }}
+      {{- include "mtSpec" (merge . $) | nindent 6 -}}
 {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23340

We need to change two places (spec manifest + revision function) to keep the resources in sync. It is error-prone. We decided to move the templates to helpers.tpl

This PR doesn't change anything in the templates. It will change the result of revision functions in the first upgrade. 

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
