### PR TITLE
align proxy values with capa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set `revisionHistoryLimit` in `MachineDeployment` as `0` for `deletion-blocker-operator`.
 - Removed `defaultStorageClass` since it was moved to the cloud provider.
+- Align Proxy values with CAPA in values file.
 
 ## [0.2.2] - 2022-08-18
 

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -24,13 +24,13 @@ spec:
   # One arm was the old implementation with dnat rule + one arm LB
   loadBalancer:
     vipSubnet: {{ .loadBalancer.vipSubnet }}
+  {{- end }}
 
   # Proxy settings
   proxyConfig:
-    httpProxy: {{ .proxyConfig.httpProxy }}
-    httpsProxy: {{ .proxyConfig.httpsProxy }}
-    noProxy: {{ .proxyConfig.noProxy }}
-  {{- end }}
+    httpProxy: {{ .Values.proxy.httpProxy }}
+    httpsProxy: {{ .Values.proxy.httpsProxy }}
+    noProxy: {{ .Values.proxy.noProxy }}
 
   # Not tested - not sure how
   {{- with .Values.cluster }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -139,20 +139,6 @@
                         "type": "string"
                     }
                 },
-                "proxyConfig": {
-                    "type": "object",
-                    "properties": {
-                        "httpProxy": {
-                            "type": "string"
-                        },
-                        "httpsProxy": {
-                            "type": "string"
-                        },
-                        "noProxy": {
-                            "type": "string"
-                        }
-                    }
-                },
                 "servicesCidrBlocks": {
                     "type": "array",
                     "items": {
@@ -165,6 +151,20 @@
                 "podsCidrBlocks",
                 "servicesCidrBlocks"
             ]
+        },
+        "proxy": {
+            "type": "object",
+            "properties": {
+                "httpProxy": {
+                    "type": "string"
+                },
+                "httpsProxy": {
+                    "type": "string"
+                },
+                "noProxy": {
+                    "type": "string"
+                }
+            }
         },
         "nodeClasses": {
             "items": {

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -43,10 +43,11 @@ network:
     port: ""  # [int] Port to use. "" defaults to 6443.
   loadBalancer:
     vipSubnet: ""  # Virtual IP CIDR for the external network.
-  proxyConfig:  # (Optional) Defines HTTP proxy environment variables.
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""  # Bypass the proxy for specific hosts - cluster IP range for instance.
+
+proxy:  # (Optional) Defines HTTP proxy environment variables.
+  httpProxy: ""
+  httpsProxy: ""
+  noProxy: ""  # Bypass the proxy for specific hosts - cluster IP range for instance.
 
 nodeClasses: []
   # - name: worker  # Name of the class to use in nodePool and machinetemplate name.


### PR DESCRIPTION
This PR:

- aligns proxy values with capa in values.yaml.

It's still slightly different from capa as we don't need to set `enabled` (leave empty or unset) and we allow to set `NO_PROXY`. CAPVCD includes proxy settings natively which are set in [cloud-init](https://github.com/vmware/cluster-api-provider-cloud-director/blob/1a163d92e426229dabd25bee0557d33583018488/controllers/cluster_scripts/cloud_init.tmpl#L109).

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
