### PR TITLE
Enforce using secretRef with refreshToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Make proxy enabled/disabled explicit to match useability of cluster-aws chart.
+- Enforce using secretRef for authentication.
 
 ## [0.2.3] - 2022-10-04
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the Helm chart used for deploying CAPI clusters via [CA
 
 ## Authentication to VCD
 
-Authentication to the VCD API is achieved as part of the cluster creation process to abide by user-defined resource quotas. At the moment, it can be achieved by referencing a secret (preferred method) or specifying creds/token in the VCDCluster definition.
+Authentication to the VCD API is achieved as part of the cluster creation process to abide by user-defined resource quotas. It can be achieved by referencing a secret (preferred method) or specifying creds/token in the VCDCluster definition. We only support referencing a secret in this app.
 
 Before deploying a cluster, make sure there is a secret containing the base64 encoded user credentials or [API token](https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html) of the VCD user in the namespace where you will deploy the cluster.
 
@@ -26,8 +26,6 @@ metadata:
   namespace: default
 type: Opaque
 data:
-  username: ""
-  password: ""
   refreshToken: "xxxxxxxxxxx"
 ```
 
@@ -84,7 +82,6 @@ ssh:
         - "xxx"
 
 userContext:
-  refreshToken: "xxxx"
   secretRef:
-    useSecretRef: false
+    secretName: "xxxxxxxx"
 ```

--- a/helm/cluster-cloud-director/ci/ci-values.yaml
+++ b/helm/cluster-cloud-director/ci/ci-values.yaml
@@ -40,6 +40,5 @@ ssh:
         - "xxx"
 
 userContext:
-  refreshToken: "xxxx"
   secretRef:
-    useSecretRef: false
+    secretName: "xxx"

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -44,12 +44,6 @@ spec:
 
   # Authentication  
   userContext:
-    {{- if .Values.userContext.secretRef.useSecretRef }}
     secretRef:
       name: {{ .Values.userContext.secretRef.secretName }}
       namespace: {{ .Release.Namespace }}
-    {{- else }}
-    refreshToken: {{ .Values.userContext.refreshToken }}
-    username: {{ .Values.userContext.username }}
-    password: {{ .Values.userContext.password }}
-    {{- end }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -255,25 +255,13 @@
         "userContext": {
             "type": "object",
             "properties": {
-                "password": {
-                    "type": "string"
-                },
-                "refreshToken": {
-                    "type": "string"
-                },
                 "secretRef": {
                     "type": "object",
                     "properties": {
                         "secretName": {
                             "type": "string"
-                        },
-                        "useSecretRef": {
-                            "type": "boolean"
                         }
                     }
-                },
-                "username": {
-                    "type": "string"
                 }
             }
         }

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -70,11 +70,5 @@ ssh:
         - ""
 
 userContext:
-  username: ""  # (Optional) ignored if refreshToken is set.
-  password: ""  # (Optional) ignored if refreshToken is set.
-  refreshToken: ""  # (Optional) refreshToken (API token).
   secretRef:
-    # If set to false, ignores secretName and you must specify username/password or refreshToken which will be in userContext of VCDCluster.
-    # If set to true, ignores username/password/refreshToken, you must specify secretName and have a pre-existing secret <= recommended method.
-    useSecretRef: true
     secretName: ""  # Name of the pre-existing secret containing the credentials of the VCD user.


### PR DESCRIPTION
cluster-apps-operator only respects secretRef with refreshToken with this PR https://github.com/giantswarm/cluster-apps-operator/pull/287

We also think we shouldn't allow putting credentials to VCDCluster CR directly.

### Testing

- [x] fresh install works
- [x] upgrade from the previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
