### PR TITLE
proxy-config injection from cluster-apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `cluster-apps-operator` generated `containerd` proxy configuration, if `proxy` is enabled
+
 ## [0.2.4] - 2022-10-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - Use `cluster-apps-operator` generated `containerd` proxy configuration, if `proxy` is enabled
+- It's possible to define an alternative `containerd` proxy configuration via `values.proxy.secretName`. Primarily used for bootstrapping new management clusters.
 
 ## [0.2.4] - 2022-10-25
 

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -19,14 +19,6 @@ Create chart name and version as used by the chart label.
 infrastructure.cluster.x-k8s.io/v1beta1
 {{- end -}}
 
-
-{{- define "proxyFiles" -}}
-- path: /etc/systemd/system/containerd.service.d/http-proxy.conf
-  permissions: "0644"
-  encoding: base64
-  content: {{ tpl ($.Files.Get "files/etc/systemd/system/containerd.service.d/http-proxy.conf") $ | b64enc }}
-{{- end -}}
-
 {{/*
 Common labels without kubernetes version
 https://github.com/giantswarm/giantswarm/issues/22441
@@ -65,7 +57,7 @@ Create a prefix for all resource names.
 use the cluster-apps-operator created secret <clusterName>-cluster-values as default
 */}}
 {{- define "containerdProxySecret" -}}
-{{- $defaultContainerdProxySecret := printf "%s-cluster-values" (include "resource.default.name" . ) -}}
+{{- $defaultContainerdProxySecret := printf "%s-systemd-proxy" (include "resource.default.name" . ) -}}
 {{ .Values.proxy.secretName | default $defaultContainerdProxySecret }}
 {{- end -}}
 

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -34,19 +34,8 @@ spec:
       {{- end }}
     {{- end }}
     {{- end }}
-    {{- if and .Values.proxy.enabled }}
-    files:
-      - path: /etc/systemd/system/containerd.service.d/99-http-proxy.conf
-        permissions: "0600"
-        contentFrom:
-          secret:
-            name: {{ include "resource.default.name" $ }}-cluster-values
-            key: containerdProxy    
-    {{- end }}
-    {{- if and .Values.proxy.enabled }}
-    preKubeadmCommands:
-    - systemctl daemon-reload
-    - systemctl restart containerd
+    {{- if $.Values.proxy.enabled }}
+    {{- include "containerdProxyConfig" . | nindent 4}}
     {{- end }}
     initConfiguration:
       nodeRegistration:

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -34,6 +34,20 @@ spec:
       {{- end }}
     {{- end }}
     {{- end }}
+    {{- if and .Values.proxy.enabled }}
+    files:
+      - path: /etc/systemd/system/containerd.service.d/99-http-proxy.conf
+        permissions: "0600"
+        contentFrom:
+          secret:
+            name: {{ include "resource.default.name" $ }}-cluster-values
+            key: containerdProxy    
+    {{- end }}
+    {{- if and .Values.proxy.enabled }}
+    preKubeadmCommands:
+    - systemctl daemon-reload
+    - systemctl restart containerd
+    {{- end }}
     initConfiguration:
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -26,14 +26,6 @@ spec:
     vipSubnet: {{ .loadBalancer.vipSubnet }}
   {{- end }}
 
-  # Proxy settings
-  {{- if .Values.proxy.enabled }}
-  proxyConfigSpec:
-    httpProxy: {{ .Values.proxy.httpProxy }}
-    httpsProxy: {{ .Values.proxy.httpsProxy }}
-    noProxy: {{ .Values.proxy.noProxy }}
-  {{- end }}
-
   # Not tested - not sure how
   {{- with .Values.cluster }}
   rdeId: {{ .rdeId }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -160,15 +160,6 @@
             "properties": {
                 "enabled": {
                     "type": "boolean"
-                },                
-                "httpProxy": {
-                    "type": "string"
-                },
-                "httpsProxy": {
-                    "type": "string"
-                },
-                "noProxy": {
-                    "type": "string"
                 }
             }
         },

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -105,8 +105,12 @@
                 },
                 "diskSize": {
                     "anyOf": [
-                       {"type": "integer"},
-                       {"type": "string"}
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        }
                     ]
                 }
             }
@@ -158,6 +162,9 @@
         "proxy": {
             "type": "object",
             "properties": {
+                "secretName": {
+                    "type": "string"
+                },
                 "enabled": {
                     "type": "boolean"
                 }
@@ -186,8 +193,12 @@
                     },
                     "diskSize": {
                         "anyOf": [
-                           {"type": "integer"},
-                           {"type": "string"}
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "string"
+                            }
                         ]
                     }
                 },
@@ -223,7 +234,7 @@
             "minItems": 1,
             "type": "array"
         },
-	"organization": {
+        "organization": {
             "type": "string"
         },
         "ssh": {
@@ -250,7 +261,11 @@
         },
         "servicePriority": {
             "type": "string",
-            "enum": ["lowest", "medium", "highest"]
+            "enum": [
+                "lowest",
+                "medium",
+                "highest"
+            ]
         },
         "userContext": {
             "type": "object",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -44,6 +44,7 @@ network:
     vipSubnet: ""  # Virtual IP CIDR for the external network.
 
 proxy:  # (Optional) Defines HTTP proxy environment variables.
+  secretName: ""
   enabled: false
 
 nodeClasses: []

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -45,9 +45,6 @@ network:
 
 proxy:  # (Optional) Defines HTTP proxy environment variables.
   enabled: false
-  httpProxy: ""
-  httpsProxy: ""
-  noProxy: ""  # Bypass the proxy for specific hosts - cluster IP range for instance.
 
 nodeClasses: []
   # - name: worker  # Name of the class to use in nodePool and machinetemplate name.


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

* The `cluster-values` secret which is newly created by `cluster-apps-operator` (open PR https://github.com/giantswarm/cluster-apps-operator/pull/290) contains a valid `containerd` proxy configuration.
* CAPI is waiting, with machine-creation, once the secret got created by `cluster-apps-operator`.
* This currently work with this (https://github.com/giantswarm/cluster-api-provider-cloud-director/pull/1) forked version of `capvcd`.

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how {APP-NAME} can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for {APP-NAME} installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update Lastpass values if required.
