### PR TITLE
Adapt kube-proxy configuration for monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Import the `cluster-shared` chart to apply additional `coredns` resources in a Workload Cluster via `ClusterResourceSets`
 - Adapt control-plane configuration by comparing CAPO.
 - ⚠️ **Breaking:** Configure encryption at REST. This requires `{{ include "resource.default.name" $ }}-encryption-provider-config` secret with `encyrption` key to be present in the cluster (can be provisioned with [encryption-provider-operator](https://github.com/giantswarm/encryption-provider-operator)).
+- Adapt kube-proxy configuration for monitoring.
 
 ## [0.3.0] - 2022-11-15
 

--- a/helm/cluster-cloud-director/files/etc/gs-kube-proxy-config.yaml
+++ b/helm/cluster-cloud-director/files/etc/gs-kube-proxy-config.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+metricsBindAddress: "0.0.0.0:10249"

--- a/helm/cluster-cloud-director/files/etc/gs-kube-proxy-patch.sh
+++ b/helm/cluster-cloud-director/files/etc/gs-kube-proxy-patch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#
+# (PK) I couldn't find a better/simpler way to conifgure it. See:
+# https://github.com/kubernetes-sigs/cluster-api/issues/4512
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x 
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+readonly dir
+
+# Run this script only if this is the init node.
+if [[ ! -f ${dir}/kubeadm.yaml ]]; then
+    exit 0
+fi
+
+# Exit fast if already appended.
+if [[ ! -f ${dir}/gs-kube-proxy-config.yaml ]]; then
+    exit 0
+fi
+
+# kubeadm config is in different directory in Flatcar (/etc) and Ubuntu (/run/kubeadm).
+kubeadm_file="/etc/kubeadm.yml"
+if [[ ! -f ${kubeadm_file} ]]; then
+    kubeadm_file="/run/kubeadm/kubeadm.yaml"
+fi
+
+cat "${dir}/gs-kube-proxy-config.yaml" >> "${dir}/kubeadm.yaml"
+rm "${dir}/gs-kube-proxy-config.yaml"

--- a/helm/cluster-cloud-director/files/etc/gs-kube-proxy-patch.sh
+++ b/helm/cluster-cloud-director/files/etc/gs-kube-proxy-patch.sh
@@ -8,10 +8,9 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -x 
+set -x
 
-dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-readonly dir
+readonly dir="/run/kubeadm"
 
 # Run this script only if this is the init node.
 if [[ ! -f ${dir}/kubeadm.yaml ]]; then
@@ -23,11 +22,5 @@ if [[ ! -f ${dir}/gs-kube-proxy-config.yaml ]]; then
     exit 0
 fi
 
-# kubeadm config is in different directory in Flatcar (/etc) and Ubuntu (/run/kubeadm).
-kubeadm_file="/etc/kubeadm.yml"
-if [[ ! -f ${kubeadm_file} ]]; then
-    kubeadm_file="/run/kubeadm/kubeadm.yaml"
-fi
-
-cat "${dir}/gs-kube-proxy-config.yaml" >> "${dir}/kubeadm.yaml"
-rm "${dir}/gs-kube-proxy-config.yaml"
+cat ${dir}/gs-kube-proxy-config.yaml >> ${dir}/kubeadm.yaml
+rm ${dir}/gs-kube-proxy-config.yaml

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -75,11 +75,11 @@ preKubeadmCommands:
 {{- end -}}
 
 {{- define "kubeProxyFiles" }}
-- path: /etc/gs-kube-proxy-config.yaml
+- path: /run/kubeadm/gs-kube-proxy-config.yaml
   permissions: "0600"
   content: |
     {{- .Files.Get "files/etc/gs-kube-proxy-config.yaml" | nindent 4 }}
-- path: /etc/gs-kube-proxy-patch.sh
+- path: /run/kubeadm/gs-kube-proxy-patch.sh
   permissions: "0700"
   content: |
     {{- .Files.Get "files/etc/gs-kube-proxy-patch.sh" | nindent 4 }}

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -74,6 +74,17 @@ preKubeadmCommands:
 - systemctl restart containerd
 {{- end -}}
 
+{{- define "kubeProxyFiles" }}
+- path: /etc/gs-kube-proxy-config.yaml
+  permissions: "0600"
+  content: |
+    {{- .Files.Get "files/etc/gs-kube-proxy-config.yaml" | nindent 4 }}
+- path: /etc/gs-kube-proxy-patch.sh
+  permissions: "0700"
+  content: |
+    {{- .Files.Get "files/etc/gs-kube-proxy-patch.sh" | nindent 4 }}
+{{- end -}}
+
 {{/*
 Updates in KubeadmConfigTemplate will not trigger any rollout for worker nodes.
 It is necessary to create a new template with a new name to trigger an upgrade.

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -89,6 +89,7 @@ spec:
         kubeletExtraArgs:
           {{- include "kubeletExtraArgs" . | nindent 10}}
     files:
+      {{- include "kubeProxyFiles" . | nindent 6 }}
       {{- range $kubeadmPatch, $_ :=  .Files.Glob  "files/etc/patches/**" }}
       - path: {{ (printf "/tmp/kubeadm/patches/%s" (base $kubeadmPatch)) }}
         content: |-
@@ -102,6 +103,7 @@ spec:
             key: encryption
     preKubeadmCommands:
       - bash /tmp/kubeadm/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
+      - bash /etc/gs-kube-proxy-patch.sh
   machineTemplate:
     infrastructureRef:
       apiVersion: {{ include "infrastructureApiVersion" . }}

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -103,7 +103,7 @@ spec:
             key: encryption
     preKubeadmCommands:
       - bash /tmp/kubeadm/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
-      - bash /etc/gs-kube-proxy-patch.sh
+      - bash /run/kubeadm/gs-kube-proxy-patch.sh
   machineTemplate:
     infrastructureRef:
       apiVersion: {{ include "infrastructureApiVersion" . }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24524

Partly copied from https://github.com/giantswarm/cluster-openstack/pull/41

Ssh part in the original PR is excluded since it is another topic. 

The logic in `gs-kube-proxy-patch.sh` and its patch was changed for CAPO while implementing ignition support. We may need to change this too. 

Node restart is also tested.

### Testing

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update Lastpass values if required.
