### PR TITLE
Fix / decouple prekubeadmcommands from the containerd function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Decouple `preKubeadmCommands` section from `containerdProxyConfig` function in `helpers.tpl`.
+
 ## [0.4.0] - 2022-11-25
 
 ### Changed

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -69,9 +69,6 @@ files:
       secret:
         name: {{ include "containerdProxySecret" $ }}
         key: containerdProxy   
-preKubeadmCommands:
-- systemctl daemon-reload
-- systemctl restart containerd
 {{- end -}}
 
 {{- define "kubeProxyFiles" }}
@@ -111,6 +108,13 @@ joinConfiguration:
 {{- if $.Values.proxy.enabled }}
 {{- include "containerdProxyConfig" . | nindent 0}}
 {{- end }}
+
+preKubeadmCommands:
+{{- if $.Values.proxy.enabled }}
+- systemctl daemon-reload
+- systemctl restart containerd
+{{- end }}
+
 {{- end -}}
 
 {{- define "kubeadmConfigTemplateRevision" -}}

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -106,6 +106,10 @@ spec:
     preKubeadmCommands:
       - bash /tmp/kubeadm/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
       - bash /run/kubeadm/gs-kube-proxy-patch.sh
+      {{- if $.Values.proxy.enabled }}
+      - systemctl daemon-reload
+      - systemctl restart containerd
+      {{- end }}
   machineTemplate:
     infrastructureRef:
       apiVersion: {{ include "infrastructureApiVersion" . }}


### PR DESCRIPTION
This PR:

- Decouples the prekubeadmcommands from the containerd function in the helpers.tpl.

Because it includes the prekubeadmcommands section, enabling proxy would break the [pre-existing prekubeadmcommands](https://github.com/giantswarm/cluster-cloud-director/commit/1bcb0560813184619e1a4b4a66b29b75e44bf692#diff-020d950d9a4447d5b10cc79003e199548cdd61a4858553c0e5c29a3597f53e3aR104-R106) section as there would be 2 of them.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update Lastpass values if required.
