### PR TITLE
Decouple prekubeadmcommand from containerd function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Decouple `preKubeadmCommands` section from `containerdProxyConfig` function in `helpers.tpl`.
+
 ## [0.4.0] - 2022-11-25
 
 ### Changed

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -69,9 +69,6 @@ files:
       secret:
         name: {{ include "containerdProxySecret" $ }}
         key: containerdProxy   
-preKubeadmCommands:
-- systemctl daemon-reload
-- systemctl restart containerd
 {{- end -}}
 
 {{- define "kubeProxyFiles" }}
@@ -111,6 +108,13 @@ joinConfiguration:
 {{- if $.Values.proxy.enabled }}
 {{- include "containerdProxyConfig" . | nindent 0}}
 {{- end }}
+
+preKubeadmCommands:
+{{- if $.Values.proxy.enabled }}
+- systemctl daemon-reload
+- systemctl restart containerd
+{{- end }}
+
 {{- end -}}
 
 {{- define "kubeadmConfigTemplateRevision" -}}

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -106,6 +106,10 @@ spec:
     preKubeadmCommands:
       - bash /tmp/kubeadm/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
       - bash /run/kubeadm/gs-kube-proxy-patch.sh
+      {{- if $.Values.proxy.enabled }}
+      - systemctl daemon-reload
+      - systemctl restart containerd
+      {{- end }}
   machineTemplate:
     infrastructureRef:
       apiVersion: {{ include "infrastructureApiVersion" . }}


### PR DESCRIPTION
This PR :  **Renamed PR**

- Decouple `prekubeadmcommands` from the `containerdProxyConfig` helper function to avoid duplicate `prekubeadmcommands` in `kubeadmcontrolplane` when proxy is enabled.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update Lastpass values if required.
