### PR TITLE
Remove serviceDomain from Cluster spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove `serviceDomain` from `Cluster` spec to fix invalid noProxy value. 
+
 ## [0.4.3] - 2022-11-28
 
 ### Added

--- a/helm/cluster-cloud-director/templates/cluster.yaml
+++ b/helm/cluster-cloud-director/templates/cluster.yaml
@@ -16,7 +16,6 @@ spec:
       {{- range .Values.network.podsCidrBlocks }}
       - {{ . }}
       {{- end }}
-    serviceDomain: {{ .Values.baseDomain }}
     services:
       cidrBlocks:
       {{- range .Values.network.servicesCidrBlocks }}


### PR DESCRIPTION
serviceDomain is used for in-cluster services and it is related to in-cluster communication.  baseDomain is mostly related to external access.
We don't set serviceDomain for other providers.

Current settings break proxy configuration since [serviceDomain is part of noProxy value](https://github.com/giantswarm/cluster-apps-operator/blob/master/service/controller/resource/clustersecret/desired.go#L165) and baseDomain shouldn't be part of noProxy value.

### Testing

- [ ] fresh install works
- [ ] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.