### PR TITLE
Remove chart name from selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove `serviceDomain` from `Cluster` spec to fix invalid noProxy value. 
+- Remove chart name (including app version) from selectors to enable upgrades.
 
 ## [0.4.3] - 2022-11-28
 

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -30,7 +30,6 @@ cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
 giantswarm.io/organization: {{ .Values.organization | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
-helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 
 {{/*
@@ -40,6 +39,7 @@ https://github.com/giantswarm/giantswarm/issues/22441
 {{- define "labels.common" -}}
 {{- include "labels.selector" . }}
 app.kubernetes.io/version: {{ $.Chart.Version | quote }}
+helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
```
{{- define "chart" -}}
{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
{{- end -}}
```

`chart` contains the chart version and it is updated by app version. When we use it in selectors, we update selectors for each app update. This is not desired. Also some selectors are immutable and this blocks app upgrades.

See OpenStack chart https://github.com/giantswarm/cluster-openstack/blob/main/helm/cluster-openstack/templates/_helpers.tpl#L27

### Testing

- [x] fresh install works
- [x] upgrade from previous version works


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update Lastpass values if required.
