### PR TITLE
Fix default nodePools value to object

### DIFF
--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -76,7 +76,7 @@ nodeClasses: {}  # Class definitions for worker node pools. The "name" of the cl
   #   storageProfile: ""
   #   diskSize: ""
 
-nodePools: []
+nodePools: {}
   # worker:
   #   class: default  # Node classes name (defined above)
   #   replicas: 2


### PR DESCRIPTION
Schema validation detected a mismatch between the `values.yaml` declaration of `nodePools: []` and the schema defining `nodePools` with type object.

Both ci-values.yaml and commented out data in values.yaml indicate that this should in fact be an object, not an array.