### PR TITLE
Add support for taints&labels for nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add configurable cluster CR labels.
 - Add schema for `.kubectlImage`.
 - Add support for `diskSizeGB`.
+- Add support for setting node labels using `customNodeLabels`.
+- Add support for setting node taints using `customNodeTaints`.
 
 ## [0.5.0] - 2022-12-18
 

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -78,6 +78,7 @@ spec:
         directory: "/tmp/kubeadm/patches"
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock
+        {{- include "taints" .Values.controlPlane.customNodeTaints | nindent 8 }}
         kubeletExtraArgs:
           {{- include "kubeletExtraArgs" . | nindent 10}}
     joinConfiguration:
@@ -85,8 +86,12 @@ spec:
         directory: "/tmp/kubeadm/patches"
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock
+        {{- include "taints" .Values.controlPlane.customNodeTaints | nindent 8 }}
         kubeletExtraArgs:
           {{- include "kubeletExtraArgs" . | nindent 10}}
+          {{- with .Values.controlPlane.customNodeLabels -}}
+          node-labels: "{{- join "," . }}"
+          {{- end }}
     files:
       {{- if $.Values.proxy.enabled }}
       {{- include "containerdProxyConfig" . | nindent 6}}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -9,6 +9,44 @@
                 "giantswarm"
             ]
         },
+        "nodeLabels": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "title": "Custom node label",
+                "pattern": "^[A-Za-z0-9-_\\./]{1,63}=[A-Za-z0-9-_\\.]{0,63}$",
+                "examples": [
+                    "key=value"
+                ]
+            }
+        },
+        "nodeTaints": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "title": "Custom node taint",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Name of the label on a node"
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "value of the label identified by the key"
+                    },
+                    "effect": {
+                        "type": "string",
+                        "description": "One of NoSchedule, PreferNoSchedule or NoExecute",
+                        "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"]
+                    }
+                },
+                "required": [
+                    "key",
+                    "effect"
+                ]
+            }
+        },
         "placementPolicy": {
             "type": "string",
             "title": "Placement policy"
@@ -125,6 +163,9 @@
             "properties": {
                 "catalog": {
                     "$ref": "#/$defs/catalog"
+                },
+                "customNodeLabels": {
+                    "$ref": "#/$defs/nodeLabels"
                 },
                 "dns": {
                     "type": "object",
@@ -295,6 +336,12 @@
                 "properties": {
                     "catalog": {
                         "$ref": "#/$defs/catalog"
+                    },
+                    "customNodeLabels": {
+                        "$ref": "#/$defs/nodeLabels"
+                    },
+                    "customNodeTaints": {
+                        "$ref": "#/$defs/nodeTaints"
                     },
                     "template": {
                         "$ref": "#/$defs/template"

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -47,6 +47,8 @@ controlPlane:  # Must match nodeClasses' fields except "name" and must contain "
   image:
     repository: projects.registry.vmware.com/tkg
   resourceRatio: 8  # Ratio between node resources and apiserver resource requests.
+  customNodeLabels: []  # Labels in key=value format.
+  # - label1=v1
 
 network:
   podsCidrBlocks:
@@ -79,6 +81,12 @@ nodeClasses: {}  # Class definitions for worker node pools. The "name" of the cl
   #   placementPolicy: ""
   #   storageProfile: ""
   #   diskSize: ""
+  #   customNodeTaints: []
+  #   # - key: "key"
+  #   #   value: "value"
+  #   #   effect: "NoSchedule"  # Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+  #   customNodeLabels: []
+  #   # - label1=val1  # Labels in key=value format
 
 nodePools: {}
   # worker:


### PR DESCRIPTION
Issue: https://github.com/giantswarm/roadmap/issues/1637

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Adds a way to mark worker or control plane nodes with labels and taints

For control planes it's possible to add the taints, but it is not obvious from the helm's value file and the json schema. I was following the same logic as was introduced and discussed [here](https://github.com/giantswarm/cluster-aws/pull/149#discussion_r1014174884).

note: We don't have the support for machine pools at CAPVCD at the moment so it's not done exactly the same as for CAP{A,G} providers, but the result should be the same.


#### Testing

tested manually on guppy using helm install

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- ~[ ] Update Lastpass values if required.~
