### PR TITLE
Support registry configuration for containerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for setting node taints using `customNodeTaints`.
 - Include common labels for `kubeadmcontrolplane.spec.machinetemplate.metadata`.
 - Fix KubeadmConfigTemplate templating when multiple ssh users are provided.
+- Support registry configuration for containerd.
 
 ## [0.5.0] - 2022-12-18
 

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -124,6 +124,7 @@ joinConfiguration:
       node-labels: "giantswarm.io/node-pool={{ .pool.name }},{{- include "labelsByClass" . -}}"
     {{- include "taintsByClass" . | nindent  4}}
 files:
+{{- include "registryFiles" . | nindent 2 }}
 {{- if $.Values.proxy.enabled }}
 {{- include "containerdProxyConfig" . | nindent 2}}
 {{- end }}
@@ -218,4 +219,65 @@ taints:
 {{- define "mtRevisionByControlPlane" -}}
 {{- $outerScope := . }}
 {{- include "mtRevision" (merge (dict "currentClass" .Values.controlPlane) $outerScope.Values) }}
+{{- end -}}
+
+{{/*
+Generate a stanza for KubeAdmConfig and KubeAdmControlPlane in order to 
+mount containerd configuration for registry configuration in nodes.
+*/}}
+{{- define "registryFiles" -}}
+{{- if and .Values.connectivity .Values.connectivity.containerRegistries -}}
+- path: /etc/containerd/conf.d/registry-config.toml
+  permissions: "0600"
+  contentFrom:
+    secret:
+      name: {{ include "registrySecretName" $ }}
+      key: registry-config.toml
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate the content of /etc/containerd/conf.d/registry-config.toml in nodes
+for registry configuration
+*/}}
+{{- define "registrySecretContent" -}}
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+{{- range $registry, $mirrors := .Values.connectivity.containerRegistries}}
+
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$registry}}"]
+{{- $endpoints := list -}}
+{{- range $mirrors }}{{- $endpoints = append $endpoints .endpoint }}{{- end }}
+endpoint = [ "{{join "\" , \"" $endpoints}}" ]
+
+{{- end }}
+
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+{{- range $registry, $mirrors := .Values.connectivity.containerRegistries}}
+{{- range $mirrors }}
+
+{{- if .credentials }}
+[plugins."io.containerd.grpc.v1.cri".registry.configs."{{.endpoint}}".auth]
+{{- range $key, $value := .credentials }}
+{{ $key}}={{$value |quote}}
+{{- end }}
+{{ end }}
+
+{{- end }}
+{{- end }}
+
+{{- end -}}
+
+{{/*
+Generate name of the k8s secret that contains containerd configuration for registries.
+When there is a change in the secret, it is not recognized by CAPI controllers.
+To enforce upgrades, a version suffix is appended to secret name.
+*/}}
+{{- define "registrySecretName" -}}
+{{- $secretSuffix := include "registrySecretContent" . | b64enc | quote | sha1sum | trunc 8 }}
+{{- include "resource.default.name" $ }}-registry-configuration-{{$secretSuffix}}
 {{- end -}}

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -97,6 +97,7 @@ spec:
       {{- include "containerdProxyConfig" . | nindent 6}}
       {{- end }}
       {{- include "kubeProxyFiles" . | nindent 6 }}
+      {{- include "registryFiles" . | nindent 6 }}
       {{- range $kubeadmPatch, $_ :=  .Files.Glob  "files/etc/patches/**" }}
       - path: {{ (printf "/tmp/kubeadm/patches/%s" (base $kubeadmPatch)) }}
         content: |-

--- a/helm/cluster-cloud-director/templates/registry-secret.yaml
+++ b/helm/cluster-cloud-director/templates/registry-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.registry .Values.registry.configure -}}
+{{- if and .Values.connectivity .Values.connectivity.containerRegistries -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/cluster-cloud-director/templates/registry-secret.yaml
+++ b/helm/cluster-cloud-director/templates/registry-secret.yaml
@@ -1,0 +1,8 @@
+{{- if and .Values.registry .Values.registry.configure -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "registrySecretName" $ }}
+data:
+  registry-config.toml: {{ include "registrySecretContent" . | b64enc | quote }}
+{{- end -}}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -96,6 +96,78 @@
                 "featureGates"
             ]
         },
+        "connectivity": {
+            "type": "object",
+            "title": "Connectivity",
+            "description": "Configurations related to cluster connectivity such as container registries.",
+            "properties": {
+                "containerRegistries": {
+                    "type": "object",
+                    "title": "Container registries",
+                    "description": "Endpoints and credentials configuration for container registries.",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "endpoint": {
+                                    "type": "string",
+                                    "title": "Endpoint",
+                                    "description": "Endpoint for the container registry."
+                                },
+                                "credentials": {
+                                    "type": "object",
+                                    "title": "Credentials",
+                                    "description": "Credentials for the endpoint.",
+                                    "properties": {
+                                        "username": {
+                                            "type": "string",
+                                            "title": "Username",
+                                            "description": "Username is the username to login the registry."
+                                        },
+                                        "password": {
+                                            "type": "string",
+                                            "title": "Password",
+                                            "description": "Password is the password to login the registry."
+                                        },
+                                        "auth": {
+                                            "type": "string",
+                                            "title": "Auth",
+                                            "description": " Auth is a base64 encoded string from the concatenation of the username, a colon, and the password."
+                                        },
+                                        "identitytoken": {
+                                            "type": "string",
+                                            "title": "Identity Token",
+                                            "description": "Identity Token is used to authenticate the user and get an access token for the registry."
+                                        }
+                                    }
+                                }
+                            },
+                            "required": [
+                                "endpoint"
+                            ]
+                        }
+                    },
+                    "examples": [
+                        {
+                            "docker.io": [
+                                { 
+                                    "endpoint": "registry-1.docker.io",
+                                    "credentials":{
+                                        "username": "my_user_name",
+                                        "password": "my_password"
+                                    }
+                                },
+                                { "endpoint": "my-mirror-registry.mydomain.io"}
+                            ]
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "containerRegistries"
+            ]
+        },
         "controllerManager": {
             "type": "object",
             "properties": {
@@ -458,6 +530,7 @@
     "required": [
         "apiServer",
         "baseDomain",
+        "connectivity",
         "controllerManager",
         "cloudDirector",
         "controlPlane",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -123,22 +123,22 @@
                                         "username": {
                                             "type": "string",
                                             "title": "Username",
-                                            "description": "Username is the username to login the registry."
+                                            "description": "Used to authenticate for the registry with username/password."
                                         },
                                         "password": {
                                             "type": "string",
                                             "title": "Password",
-                                            "description": "Password is the password to login the registry."
+                                            "description": "Used to authenticate for the registry with username/password."
                                         },
                                         "auth": {
                                             "type": "string",
                                             "title": "Auth",
-                                            "description": " Auth is a base64 encoded string from the concatenation of the username, a colon, and the password."
+                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
                                         },
                                         "identitytoken": {
                                             "type": "string",
-                                            "title": "Identity Token",
-                                            "description": "Identity Token is used to authenticate the user and get an access token for the registry."
+                                            "title": "Identity token",
+                                            "description": "Used to authenticate the user and obtain an access token for the registry."
                                         }
                                     }
                                 }
@@ -147,21 +147,7 @@
                                 "endpoint"
                             ]
                         }
-                    },
-                    "examples": [
-                        {
-                            "docker.io": [
-                                { 
-                                    "endpoint": "registry-1.docker.io",
-                                    "credentials":{
-                                        "username": "my_user_name",
-                                        "password": "my_password"
-                                    }
-                                },
-                                { "endpoint": "my-mirror-registry.mydomain.io"}
-                            ]
-                        }
-                    ]
+                    }
                 }
             },
             "required": [

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -530,7 +530,6 @@
     "required": [
         "apiServer",
         "baseDomain",
-        "connectivity",
         "controllerManager",
         "cloudDirector",
         "controlPlane",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -121,4 +121,4 @@ connectivity:
 #   - endpoint: "my-mirror-registry.mydomain.io"
 #     credentials:
 #       auth: ""
-#       identityToken: ""
+#       identitytoken: ""

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -110,3 +110,15 @@ kubectlImage:
   registry: quay.io
   name: giantswarm/kubectl
   tag: 1.23.5
+
+connectivity:
+  containerRegistries: {}
+#   docker.io:
+#   - endpoint: "registry-1.docker.io"
+#     credentials:
+#       username: ""
+#       password: ""
+#   - endpoint: "my-mirror-registry.mydomain.io"
+#     credentials:
+#       auth: ""
+#       identityToken: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24237

---
Notes for reviewer
- This is a reference implementation for https://github.com/giantswarm/rfc/pull/49. Other providers are supposed to mimic this implementation.
- Harbor will be deployed into MC and this configuration interface will allow us to add harbor as mirror registry for usual registries including its credentials. Container Solution folks confirmed it.
- The interface is as below. `containerRegistries` is a map instead of an array since map allows us to merge values for customization. Customers will be able to add their own registries.
 
 ```
connectivity:
  containerRegistries:
    docker.io: 
     - endpoint: "registry-1.docker.io"
        credentials:
          username: "my_user_name"
          password: "my_password"
    - endpoint: "my-mirror-registry.mydomain.io"
```

---
Example app platform configuration
```
connectivity:
  containerRegistries:
    docker.io:
    - endpoint: registry-1.docker.io
      credentials:
        username: "erkanerol"
        password: "dckr_pat_erkanerol_password"
    - endpoint: giantswarm.azurecr.io
```
---
Example user configuration
```
connectivity:
  containerRegistries:
    quay.io:
    - endpoint: quay.io
      credentials:
        username: "erkanerolgs+pulltoken"
        password: "erkanerolgspassword"
    gcr.io:
    - endpoint: gcr.io
      credentials:
        auth: "myauth"
        identitytoken: "myIdentityToken"
```
---
---
Example output (content of registry-config.toml file)
```
version = 2

[plugins."io.containerd.grpc.v1.cri".registry]

[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
endpoint = [ "registry-1.docker.io", "giantswarm.azurecr.io" ]
[plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
endpoint = [ "quay.io" ]
[plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
endpoint = [ "gcr.io" ]

[plugins."io.containerd.grpc.v1.cri".registry.configs]
[plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
password="dckr_pat_erkanerol_password"
username="erkanerol"
[plugins."io.containerd.grpc.v1.cri".registry.configs."quay.io".auth]
password="erkanerolgspassword"
username="erkanerolgs+pulltoken"
[plugins."io.containerd.grpc.v1.cri".registry.configs."gcr.io".auth]
auth="mygcrtoken"
identitytoken="myidentity"
```
### Testing

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
~~[ ]Update Lastpass values if required.~~
