### PR TITLE
Fix kubeadmConfigTemplateSpec for multiple ssh users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for setting node labels using `customNodeLabels`.
 - Add support for setting node taints using `customNodeTaints`.
 - Include common labels for `kubeadmcontrolplane.spec.machinetemplate.metadata`.
+- Fix KubeadmConfigTemplate templating when multiple ssh users are provided.
 
 ## [0.5.0] - 2022-12-18
 

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -106,9 +106,9 @@ See https://github.com/kubernetes-sigs/cluster-api/issues/4910
 See https://github.com/kubernetes-sigs/cluster-api/pull/5027/files
 */}}
 {{- define "kubeadmConfigTemplateSpec" -}}
-{{- if $.Values.ssh.users }}
-{{- range $.Values.ssh.users -}}
+{{- if $.Values.ssh.users -}}
 users:
+{{- range $.Values.ssh.users }}
 - name: {{ .name }}
   sshAuthorizedKeys:
   {{- range .authorizedKeys }}


### PR DESCRIPTION
When `ssh.users` have more than 1 element, the current templating is broken.

Tested for len(ssh.users) is 0,1 and 2.

### Testing

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update Lastpass values if required.
