### PR TITLE
move static routes to prekubeadmcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved Static routes script from `postKubeadmCommand` to `preKubeadmCommand`.
+
 ## [0.6.0] - 2023-01-30
 
 ### Added

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -128,12 +128,12 @@ preKubeadmCommands:
 - systemctl daemon-reload
 - systemctl restart containerd
 {{- end }}
-postKubeadmCommands:
-{{ include "sshPostKubeadmCommands" . }}
 {{- if $.Values.network.staticRoutes }}
 - systemctl daemon-reload
 - systemctl enable --now static-routes.service
 {{- end }}
+postKubeadmCommands:
+{{ include "sshPostKubeadmCommands" . }}
 {{- end -}}
 
 {{- define "kubeadmConfigTemplateRevision" -}}

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -111,12 +111,12 @@ spec:
       - systemctl daemon-reload
       - systemctl restart containerd
       {{- end }}
-    postKubeadmCommands:  
-      {{- include "sshPostKubeadmCommands" . | nindent 6 }}
       {{- if $.Values.network.staticRoutes }}
       - systemctl daemon-reload
       - systemctl enable --now static-routes.service
       {{- end }}
+    postKubeadmCommands:  
+      {{- include "sshPostKubeadmCommands" . | nindent 6 }}
   machineTemplate:
     metadata:
       labels: {{- include "labels.common" . | nindent 8 }}


### PR DESCRIPTION
We move the static routes setting to `prekubeadmcommand `as opposed to `postkubeadmcommand`, otherwise it fails to download the etcd image during bootstrapping in Panamax because it requires a static route to the subnet where the http proxy lives.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update Lastpass values if required.
