### PR TITLE
Cleanup HelmRelease CRs on deletion

### DIFF
--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -45,7 +45,7 @@ rules:
     resourceNames:
       - "{{ include "resource.default.name" $ }}-cilium"
       - "{{ include "resource.default.name" $ }}-cloud-provider-cloud-director"
-    verbs: ["get", "patch"]
+    verbs: ["get", "list", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -1,0 +1,111 @@
+# Because cluster provider resources are often deleted before flux has a chance
+# to uninstall helm releases for all deleted HelmRelease CRs they become
+# leftovers because there is still flux finalizer on them. This looks like
+# following:
+#
+#     $ kubectl get helmrelease -n org-multi-project
+#     NAME                                  AGE     READY   STATUS
+#     pawe1-cilium                          99m     False   failed to get last release revision
+#     pawe1-cloud-provider-cloud-director   99m     False   failed to get last release revision
+#
+# Both HelmRelease CRs in this case have deletionTimestamp and finalizers set,
+# e.g.:
+#
+#     deletionTimestamp: "2023-03-02T14:34:49Z"
+#     finalizers:
+#       - finalizers.fluxcd.io
+#
+# To work around this post-delete Job deletes all finalizers on all HelmRelease
+# CRs created with this chart.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+rules:
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    resourceNames:
+      - "{{ include "resource.default.name" $ }}-cilium"
+      - "{{ include "resource.default.name" $ }}-cloud-provider-cloud-director"
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
+    namespace: "{{ $.Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 86400 # 24h
+  template:
+    metadata:
+      name: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
+      namespace: "{{ $.Release.Namespace }}"
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
+      securityContext:
+        runAsUser: {{ include "securityContext.runAsUser" $ }}
+        runAsGroup: {{ include "securityContext.runAsGroup" $ }}
+      containers:
+        - name: post-delete-job
+          image: "{{ .Values.kubectlImage.registry }}/{{ .Values.kubectlImage.name }}:{{ .Values.kubectlImage.tag }}"
+          command:
+            - "/bin/sh"
+            - "-xc"
+            - |
+              for r in $(kubectl get helmrelease -n {{ $.Release.Namespace }} -l "giantswarm.io/cluster={{ include "resource.default.name" . }}" -o name) ; do
+                  kubectl patch -n {{ $.Release.Namespace }} "${r}" --type=merge -p '{"metadata": {"finalizers": []}}'
+              done
+          securityContext:
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "10m"
+            limits:
+              memory: "256Mi"
+              cpu: "100m"

--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -25,7 +25,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 ---
@@ -36,7 +37,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 rules:
@@ -57,7 +59,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-delete"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 subjects:
@@ -77,6 +80,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-delete"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 spec:

--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -42,10 +42,13 @@ metadata:
 rules:
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
+    verbs: ["get", "list"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
     resourceNames:
       - "{{ include "resource.default.name" $ }}-cilium"
       - "{{ include "resource.default.name" $ }}-cloud-provider-cloud-director"
-    verbs: ["get", "list", "patch"]
+    verbs: ["patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
@@ -21,7 +21,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-install,pre-upgrade,post-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 ---
@@ -32,7 +33,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-install,pre-upgrade,post-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 rules:
@@ -52,7 +54,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 subjects:
@@ -74,6 +77,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
 spec:
   ttlSecondsAfterFinished: 86400 # 24h
   template:
@@ -116,6 +120,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
 spec:
   ttlSecondsAfterFinished: 86400 # 24h
   template:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23449

https://github.com/giantswarm/cluster-cloud-director/pull/93 should be merged first ✅ 

Please read the comment at the top of the added file for description.

The changelog is not updated because previous changes are not yet released.

Verification:

```
$ k logs -n org-multi-project pawe5-cleanup-helmreleases-hook--1-tw6mm
+ kubectl get helmrelease -n org-multi-project -l giantswarm.io/cluster=pawe5 -o name
+ kubectl patch -n org-multi-project helmrelease.helm.toolkit.fluxcd.io/pawe5-cilium --type=merge -p {"metadata": {"finalizers": []}}
helmrelease.helm.toolkit.fluxcd.io/pawe5-cilium patched
+ kubectl patch -n org-multi-project helmrelease.helm.toolkit.fluxcd.io/pawe5-cloud-provider-cloud-director --type=merge -p {"metadata": {"finalizers": []}}
helmrelease.helm.toolkit.fluxcd.io/pawe5-cloud-provider-cloud-director patched
```