### PR TITLE
Fix hook resource order and GC

### DIFF
--- a/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
@@ -21,7 +21,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-install,pre-upgrade,post-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 ---
@@ -32,7 +33,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-install,pre-upgrade,post-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 rules:
@@ -52,7 +54,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "-1"
   labels:
     {{- include "labels.common" $ | nindent 4 }}
 subjects:
@@ -74,6 +77,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
 spec:
   ttlSecondsAfterFinished: 86400 # 24h
   template:
@@ -116,6 +120,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
 spec:
   ttlSecondsAfterFinished: 86400 # 24h
   template:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23449

This PR fixes two things:

- It makes sure ServiceAccount Role and RoleBinding are created before the Job is created
- It makes sure they are deleted (regardless of the Job execution being successful or not)
- Note that Job resources have TTL set so they are not deleted by Helm for debugging purposes

The changelog is not updated because hooks are not yet released.