### PR TITLE
Don't put clusterLabels on HelmRe{lease,pository} CRs

### DIFF
--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -6,8 +6,6 @@ metadata:
   annotations:
     cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
   labels:
-    cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
 spec:
   releaseName: cilium

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -9,9 +9,6 @@ metadata:
     cluster-apps-operator.giantswarm.io/watching: ""
     giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
-    {{- range $key, $val := .Values.clusterLabels }}
-    {{ $key }}: {{ $val | quote }}
-    {{- end}}
 spec:
   releaseName: cilium
   targetNamespace: kube-system

--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -15,7 +15,7 @@
 #     finalizers:
 #       - finalizers.fluxcd.io
 #
-# To work around this post-delete Job deletes all finalizers on all HelmRelease
+# To work around this, post-delete Job deletes all finalizers on all HelmRelease
 # CRs created with this chart.
 #
 apiVersion: v1

--- a/helm/cluster-cloud-director/templates/default-helmrepository.yaml
+++ b/helm/cluster-cloud-director/templates/default-helmrepository.yaml
@@ -6,8 +6,6 @@ metadata:
   annotations:
     cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
   labels:
-    cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
 spec:
   interval: 10m

--- a/helm/cluster-cloud-director/templates/default-helmrepository.yaml
+++ b/helm/cluster-cloud-director/templates/default-helmrepository.yaml
@@ -9,9 +9,6 @@ metadata:
     cluster-apps-operator.giantswarm.io/watching: ""
     giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
     {{- include "labels.common" . | nindent 4 }}
-    {{- range $key, $val := .Values.clusterLabels }}
-    {{ $key }}: {{ $val | quote }}
-    {{- end}}
 spec:
   interval: 10m
   url: https://giantswarm.github.io/default-catalog


### PR DESCRIPTION
note:
this line
```
for r in $(kubectl get helmrelease -n {{ $.Release.Namespace }} -l "giantswarm.io/cluster={{ include "resource.default.name" . }}" -o name) ; do
```
([source](https://github.com/giantswarm/cluster-cloud-director/blob/60a6aa02530f7a72f94963b856077a8b39085a36/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml#L107))
should be ok, because this particular label is [added](https://github.com/giantswarm/cluster-cloud-director/blob/60a6aa02530f7a72f94963b856077a8b39085a36/helm/cluster-cloud-director/templates/_helpers.tpl#L30) by `labels.common` helper.