### PR TITLE
fixes templating of postkubeadm commands

### DIFF
--- a/helm/cluster-cloud-director/templates/_ntp.tpl
+++ b/helm/cluster-cloud-director/templates/_ntp.tpl
@@ -30,7 +30,7 @@
 {{- end }}
 
 {{- define "ntpPostKubeadmCommands" -}}
-{{- if or $.Values.ntp.pools $.Values.ntp.servers -}}
+{{- if or $.Values.ntp.pools $.Values.ntp.servers }}
 - systemctl daemon-reload
 - systemctl restart chrony
 {{- end -}}


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- fixes kubeadmconfigtemplate formatting when NTP servers are provided.

before:

```
      postKubeadmCommands:
      - systemctl restart sshd- systemctl daemon-reload
      - systemctl restart chrony
```

after:

```
      postKubeadmCommands:
      - systemctl restart sshd
      - systemctl daemon-reload
      - systemctl restart chrony
```


