### PR TITLE
bump cloud provider version to v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump cloud provider to v0.2.4.
+
 ## [0.7.2] - 2023-03-16
 
 ### Fixed

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: cloud-provider-cloud-director
-      version: 0.2.3
+      version: 0.2.4
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default


### PR DESCRIPTION
New clusters in customer environment must be created with `enableVirtualServiceSharedIP` default value to `true`.
(until exposed in the values here).

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update Lastpass values if required.
