### PR TITLE
Fix pre-upgrade hook Job RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix RBAC for pre-upgrade hook.
+
 ## [0.8.0] - 2023-03-17
 
 ### Changed

--- a/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
@@ -53,7 +53,7 @@ metadata:
   name: "{{ include "resource.default.name" $ }}-update-values-hook"
   namespace: "{{ $.Release.Namespace }}"
   annotations:
-    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook": "post-install,pre-upgrade,post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
     "helm.sh/hook-weight": "-1"
   labels:


### PR DESCRIPTION
Otherwise:

```
k --kubeconfig=./kubeconfigs/kind-mc-initial-leopard.kubeconfig -n org-giantswarm  logs leopard-pre-upgrade-suspend-hook-fdj68
+ kubectl patch helmrelease -n org-giantswarm leopard-cloud-provider-cloud-director --type=merge -p {"spec":{"suspend":true}}
Error from server (Forbidden): helmreleases.helm.toolkit.fluxcd.io "leopard-cloud-provider-cloud-director" is forbidden: User "system:serviceaccount:org-giantswarm:leopard-update-values-hook" cannot get resource "helmreleases" in API group "helm.toolkit.fluxcd.io" in the namespace "org-giantswarm"
```