### PR TITLE
Make cloud provider `VirtualServiceSharedIP` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Make cloud provider `VirtualServiceSharedIP` configurable.
+
 ### Fixed
 
 - Fix RBAC for pre-upgrade hook.

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -50,3 +50,6 @@ spec:
         site: {{ .Values.cloudDirector.site | quote }}
         vAppName: {{ include "resource.default.name" $  | quote }}
         vipSubnet: {{ .Values.network.loadBalancer.vipSubnet | quote }}
+        enableVirtualServiceSharedIP: {{ .Values.cloudProvider.enableVirtualServiceSharedIP }}
+        oneArm:
+          enabled: {{ .Values.cloudProvider.oneArm.enabled }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -131,6 +131,25 @@
             ],
             "type": "object"
         },
+        "cloudProvider": {
+            "properties": {
+                "enableVirtualServiceSharedIP": {
+                    "type": "boolean"
+                },
+                "oneArm": {
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "enableVirtualServiceSharedIP",
+                "oneArm"
+            ],
+            "type": "object"
+        },
         "cluster": {
             "properties": {
                 "parentUid": {

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -19,6 +19,11 @@ cloudDirector:
   ovdc: ""  # VCD virtual datacenter.
   ovdcNetwork: ""  # VCD network to connect VMs.
 
+cloudProvider:
+  enableVirtualServiceSharedIP: true  # Multiple VS can share an IP if true.
+  oneArm:
+    enabled: false  # Creates a NAT rule instead of direct LB IP if true.
+
 cluster:
   rdeId: ""  # (Optional) If empty, CAPVCD will create one.
   parentUid: ""  # (Optional) Create the CAPVCD cluster from a specific management cluster associated with this UID.


### PR DESCRIPTION
This PR:

- Makes the `VirtualServiceSharedIP` field configurable. Otherwise, clusters created in VCD environment < 10.4 _(Guppy)_ will get the [default value](https://github.com/giantswarm/cloud-provider-cloud-director-app/blob/main/helm/cloud-provider-cloud-director/values.yaml#L15) set to `true` which should be `false`. 

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
