### PR TITLE
Fix values schema for .network.ntp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix values schema for `.network.ntp` object.
+
 ## [0.8.1] - 2023-03-23
 
 ### Added

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -361,17 +361,21 @@
                     "type": "object"
                 },
                 "ntp": {
-                    "type": "array",
-                    "servers": {
-                        "items": {
-                            "type": "string"
+                    "properties": {
+                        "pools": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "servers": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
-                    "pools": {
-                        "items": {
-                            "type": "string"
-                        }
-                    }
+                    "type": "object"
                 },
                 "podsCidrBlocks": {
                     "items": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2096

This PR:

- fixes the schema for the `.network.ntp` object.

Working with `schemalint` and the cluster-app rule set in the future will help prevent such errors. We will bring the schema in shape to make that possible. :)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.
