### PR TITLE
Copy default values into schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `default-test` HelmRepository (catalog) for debugging.
 - Added annotations (title, description, examples) to the values schema.
+- Values schema: Added type definition for properties where they were missing.
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - :boom: **Breaking:** Install CoreDNS (`coredns-app`) using `HelmRelease` CR and stop deploying it with `cluster-shared` resource set.
 - Bump infrastructureApiVersion from v1beta1 to v1beta2.
 - Bump coredns-app to 1.15.1 to support Kubernetes 1.24.
+- Specify JSON Schema draft of values schema.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `default-test` HelmRepository (catalog) for debugging.
 - Added annotations (title, description, examples) to the values schema.
 - Values schema: Added type definition for properties where they were missing.
+- Values schema: Add default values
 
 ### Changed
 

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -469,7 +469,8 @@
                                 "title": "Server",
                                 "type": "string"
                             },
-                            "title": "Servers"
+                            "title": "Servers",
+                            "type": "array"
                         }
                     },
                     "title": "Time synchronization (NTP)",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -87,6 +87,7 @@
         "apiServer": {
             "properties": {
                 "certSANs": {
+                    "default": [],
                     "description": "Alternative names to encode in the API server's certificate.",
                     "items": {
                         "title": "SAN",
@@ -96,11 +97,13 @@
                     "type": "array"
                 },
                 "enableAdmissionPlugins": {
+                    "default": "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
                     "description": "Comma-separated list of admission plugins to enable.",
                     "title": "Admission plugins",
                     "type": "string"
                 },
                 "featureGates": {
+                    "default": "TTLAfterFinished=true",
                     "description": "Enabled feature gates, as a comma-separated list.",
                     "title": "Feature gates",
                     "type": "string"
@@ -114,27 +117,32 @@
             "type": "object"
         },
         "baseDomain": {
+            "default": "k8s.test",
             "title": "Base DNS domain",
             "type": "string"
         },
         "cloudDirector": {
             "properties": {
                 "org": {
+                    "default": "",
                     "description": "VCD organization name.",
                     "title": "Organization",
                     "type": "string"
                 },
                 "ovdc": {
+                    "default": "",
                     "description": "Name of the organization virtual datacenter (OvDC) to create this cluster in.",
                     "title": "OvDC name",
                     "type": "string"
                 },
                 "ovdcNetwork": {
+                    "default": "",
                     "description": "VCD network to connect VMs.",
                     "title": "OvDC network",
                     "type": "string"
                 },
                 "site": {
+                    "default": "",
                     "description": "VCD endpoint URL in the format https://VCD_HOST, without trailing slash.",
                     "title": "Endpoint",
                     "type": "string"
@@ -152,6 +160,7 @@
         "cloudProvider": {
             "properties": {
                 "enableVirtualServiceSharedIP": {
+                    "default": true,
                     "description": "If enabled, multiple virtual services can share the same virtual IP address.",
                     "title": "Enable sharing of IPs in virtual services",
                     "type": "boolean"
@@ -160,6 +169,7 @@
                     "description": "If enabled, use an internal IP for the virtual service with a NAT rule to expose the external IP. Otherwise the virtual service will be exposed directly with the external IP.",
                     "properties": {
                         "enabled": {
+                            "default": false,
                             "title": "Enable",
                             "type": "boolean"
                         }
@@ -178,16 +188,19 @@
         "cluster": {
             "properties": {
                 "parentUid": {
+                    "default": "",
                     "description": "If set, create the cluster from a specific management cluster associated with this UID.",
                     "title": "Management cluster UID",
                     "type": "string"
                 },
                 "rdeId": {
+                    "default": "",
                     "description": "This cluster's entity ID in the VCD API.",
                     "title": "RDE ID",
                     "type": "string"
                 },
                 "useAsManagementCluster": {
+                    "default": false,
                     "title": "Display as management cluster",
                     "type": "boolean"
                 }
@@ -196,11 +209,13 @@
             "type": "object"
         },
         "clusterDescription": {
+            "default": "",
             "description": "User-friendly description of the cluster's purpose.",
             "title": "Cluster description",
             "type": "string"
         },
         "clusterLabels": {
+            "default": {},
             "description": "Used for adding configurable labels to the cluster resource.",
             "title": "Cluster labels",
             "type": "object"
@@ -252,6 +267,7 @@
                         },
                         "type": "array"
                     },
+                    "default": {},
                     "description": "Endpoints and credentials configuration for container registries.",
                     "title": "Container registries",
                     "type": "object"
@@ -267,11 +283,13 @@
             "properties": {
                 "catalog": {
                     "$ref": "#/$defs/catalog",
+                    "default": "",
                     "description": "VCD catalog where the VM template is stored.",
                     "title": "Catalog"
                 },
                 "customNodeLabels": {
                     "$ref": "#/$defs/nodeLabels",
+                    "default": [],
                     "title": "Custom node labels"
                 },
                 "diskSizeGB": {
@@ -281,6 +299,7 @@
                 "dns": {
                     "properties": {
                         "imageRepository": {
+                            "default": "projects.registry.vmware.com/tkg",
                             "examples": [
                                 "projects.registry.vmware.com/tkg"
                             ],
@@ -288,6 +307,7 @@
                             "type": "string"
                         },
                         "imageTag": {
+                            "default": "v1.7.0_vmware.12",
                             "examples": [
                                 "v1.7.0_vmware.12"
                             ],
@@ -301,6 +321,7 @@
                 "etcd": {
                     "properties": {
                         "imageRepository": {
+                            "default": "giantswarm",
                             "examples": [
                                 "giantswarm"
                             ],
@@ -308,6 +329,7 @@
                             "type": "string"
                         },
                         "imageTag": {
+                            "default": "3.5.4-0-k8s",
                             "examples": [
                                 "3.5.4-0-k8s"
                             ],
@@ -321,6 +343,7 @@
                 "image": {
                     "properties": {
                         "repository": {
+                            "default": "projects.registry.vmware.com/tkg",
                             "examples": [
                                 "projects.registry.vmware.com/tkg"
                             ],
@@ -333,14 +356,17 @@
                 },
                 "placementPolicy": {
                     "$ref": "#/$defs/placementPolicy",
+                    "default": "",
                     "title": "VM placement policy"
                 },
                 "replicas": {
                     "description": "Number of control plane instances to create. Must be an odd number.",
+                    "replicas": 0,
                     "title": "Number of nodes",
                     "type": "integer"
                 },
                 "resourceRatio": {
+                    "default": 8,
                     "description": "Ratio between node resources and apiserver resource requests.",
                     "minimum": 2,
                     "title": "Resource ratio",
@@ -348,14 +374,17 @@
                 },
                 "sizingPolicy": {
                     "$ref": "#/$defs/sizingPolicy",
+                    "default": "",
                     "title": "Sizing policy"
                 },
                 "storageProfile": {
                     "$ref": "#/$defs/storageProfile",
+                    "default": "",
                     "title": "Storage profile"
                 },
                 "template": {
                     "$ref": "#/$defs/template",
+                    "default": "",
                     "title": "VM template"
                 }
             },
@@ -373,6 +402,7 @@
         "controllerManager": {
             "properties": {
                 "featureGates": {
+                    "default": "ExpandPersistentVolumes=true,TTLAfterFinished=true",
                     "description": "Comma-separated list of feature gates.",
                     "examples": [
                         "ExpandPersistentVolumes=true,TTLAfterFinished=true"
@@ -395,14 +425,17 @@
             "description": "Used by cluster-shared library chart to configure coredns in-cluster.",
             "properties": {
                 "name": {
+                    "default": "giantswarm/kubectl",
                     "title": "Repository",
                     "type": "string"
                 },
                 "registry": {
+                    "default": "quay.io",
                     "title": "Registry",
                     "type": "string"
                 },
                 "tag": {
+                    "default": "1.23.5",
                     "title": "Tag",
                     "type": "string"
                 }
@@ -411,6 +444,7 @@
             "type": "object"
         },
         "kubernetesVersion": {
+            "default": "",
             "title": "Kubernetes version",
             "type": "string"
         },
@@ -420,10 +454,12 @@
                     "description": "Kubernetes API endpoint.",
                     "properties": {
                         "host": {
+                            "default": "",
                             "title": "Host",
                             "type": "string"
                         },
                         "port": {
+                            "default": "",
                             "title": "Port number",
                             "type": "string"
                         }
@@ -432,6 +468,7 @@
                     "type": "object"
                 },
                 "extraOvdcNetworks": {
+                    "default": [],
                     "description": "OVDC networks to attach VMs to, additionally.",
                     "items": {
                         "type": "string"
@@ -442,6 +479,7 @@
                 "loadBalancer": {
                     "properties": {
                         "vipSubnet": {
+                            "default": "",
                             "description": "Virtual IP CIDR for the external network.",
                             "title": "Virtual IP subnet",
                             "type": "string"
@@ -454,6 +492,7 @@
                     "description": "Servers/pools to synchronize this cluster's clocks with.",
                     "properties": {
                         "pools": {
+                            "default": [],
                             "items": {
                                 "examples": [
                                     "ntp.ubuntu.com"
@@ -465,6 +504,7 @@
                             "type": "array"
                         },
                         "servers": {
+                            "default": [],
                             "items": {
                                 "title": "Server",
                                 "type": "string"
@@ -477,6 +517,9 @@
                     "type": "object"
                 },
                 "podsCidrBlocks": {
+                    "default": [
+                        "100.96.0.0/11"
+                    ],
                     "description": "IPv4 address range for pods, in CIDR notation.",
                     "items": {
                         "type": "string"
@@ -487,6 +530,9 @@
                     "type": "array"
                 },
                 "servicesCidrBlocks": {
+                    "default": [
+                        "100.64.0.0/13"
+                    ],
                     "description": "IPv4 address range for services, in CIDR notation.",
                     "items": {
                         "type": "string"
@@ -497,6 +543,7 @@
                     "type": "array"
                 },
                 "staticRoutes": {
+                    "default": [],
                     "items": {
                         "properties": {
                             "destination": {
@@ -561,6 +608,7 @@
                 },
                 "type": "object"
             },
+            "default": {},
             "description": "Re-usable node configuration.",
             "title": "Node classes",
             "type": "object"
@@ -579,6 +627,7 @@
                 },
                 "type": "object"
             },
+            "default": {},
             "description": "Groups of worker nodes with identical configuration.",
             "title": "Node pools",
             "type": "object"
@@ -586,31 +635,37 @@
         "oidc": {
             "properties": {
                 "caFile": {
+                    "default": "",
                     "description": "Path to identity provider's CA certificate in PEM format.",
                     "title": "Certificate authority file",
                     "type": "string"
                 },
                 "clientId": {
+                    "default": "",
                     "description": "OIDC client identifier to identify with.",
                     "title": "Client ID",
                     "type": "string"
                 },
                 "groupsClaim": {
+                    "default": "",
                     "description": "Name of the identity token claim bearing the user's group memberships.",
                     "title": "Groups claim",
                     "type": "string"
                 },
                 "issuerUrl": {
+                    "default": "",
                     "description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part.",
                     "title": "Issuer URL",
                     "type": "string"
                 },
                 "usernameClaim": {
+                    "default": "",
                     "description": "Name of the identity token claim bearing the unique user identifier.",
                     "title": "Username claim",
                     "type": "string"
                 },
                 "usernamePrefix": {
+                    "default": "",
                     "description": "Prefix prepended to username values to prevent clashes with existing names.",
                     "title": "Username prefix",
                     "type": "string"
@@ -626,10 +681,17 @@
             "type": "object"
         },
         "organization": {
+            "default": "",
             "title": "Organization",
             "type": "string"
         },
         "osUsers": {
+            "default": [
+                {
+                    "name": "giantswarm",
+                    "sudo": "ALL=(ALL) NOPASSWD:ALL"
+                }
+            ],
             "description": "Configuration for OS users in cluster nodes.",
             "items": {
                 "properties": {
@@ -652,10 +714,12 @@
             "description": "Whether/how outgoing traffic is routed through proxy servers.",
             "properties": {
                 "enabled": {
+                    "default": false,
                     "title": "Enable",
                     "type": "boolean"
                 },
                 "secretName": {
+                    "default": "",
                     "description": "Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables.",
                     "title": "Secret name",
                     "type": "string"
@@ -665,6 +729,7 @@
             "type": "object"
         },
         "servicePriority": {
+            "default": "highest",
             "description": "The relative importance of this cluster.",
             "enum": [
                 "lowest",
@@ -675,6 +740,9 @@
             "type": "string"
         },
         "sshTrustedUserCAKeys": {
+            "default": [
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
+            ],
             "description": "CA certificates of issuers that are trusted to sign SSH user certificates.",
             "items": {
                 "type": "string"
@@ -687,6 +755,7 @@
                 "secretRef": {
                     "properties": {
                         "secretName": {
+                            "default": "",
                             "description": "Name of the pre-existing secret containing the credentials of the VCD user.",
                             "title": "Name",
                             "type": "string"

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -164,7 +164,8 @@
                             "type": "boolean"
                         }
                     },
-                    "title": "One-arm"
+                    "title": "One-arm",
+                    "type": "object"
                 }
             },
             "required": [

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -461,7 +461,8 @@
                                 "title": "Pool",
                                 "type": "string"
                             },
-                            "title": "Pools"
+                            "title": "Pools",
+                            "type": "array"
                         },
                         "servers": {
                             "items": {

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -82,7 +82,7 @@
             "type": "string"
         }
     },
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "apiServer": {
             "properties": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2328

This PR copies the default values from `values.yaml` to `values.schema.json`, as an intermediate step.

In the next steps, the `values.yaml` file will get generated based on the schema and we are going to eliminate empty default values.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.
