### PR TITLE
Move NTP settings in values.yaml into `.network`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `values.yaml` to set NTP settings in `.network.ntp` and adapt template.
+
 ## [0.9.0] - 2023-04-05
 
 ### Added

--- a/helm/cluster-cloud-director/templates/_ntp.tpl
+++ b/helm/cluster-cloud-director/templates/_ntp.tpl
@@ -1,17 +1,17 @@
 # The helper functions here can be called in templates and _helpers.tpl
-# This file should be self-sufficient. Don't call any functions from _helpers.tpl
+# This file should be self-sufficient. Don't call any functions from _helpers.tpl
 
 
 {{- define "ntpFiles" -}}
-{{- if or $.Values.ntp.pools $.Values.ntp.servers -}}
+{{- if or $.Values.network.ntp.pools $.Values.network.ntp.servers -}}
 - path: /etc/chrony/chrony.conf
   permissions: "0644"
   content: |
-    {{- range $.Values.ntp.pools}}
+    {{- range $.Values.network.ntp.pools}}
     pool {{.}} iburst
     {{- end }}
 
-    {{- range $.Values.ntp.servers}}
+    {{- range $.Values.network.ntp.servers}}
     server {{.}} iburst
     {{- end }}
 
@@ -30,7 +30,7 @@
 {{- end }}
 
 {{- define "ntpPostKubeadmCommands" -}}
-{{- if or $.Values.ntp.pools $.Values.ntp.servers }}
+{{- if or $.Values.network.ntp.pools $.Values.network.ntp.servers }}
 - systemctl daemon-reload
 - systemctl restart chrony
 {{- end -}}

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -75,6 +75,9 @@ network:
   extraOvdcNetworks: []  # Ovdc networks to attach VMs in addition to .cloudDirector.ovdcNetwork
 # - network-1
 # - network-2
+  ntp:  # ntp pools and servers chrony config
+    servers: []
+    pools: []
 
 proxy:  # (Optional) Defines HTTP proxy environment variables.
   secretName: ""
@@ -99,10 +102,6 @@ nodePools: {}
   # worker:
   #   class: default  # Node classes name (defined above)
   #   replicas: 2
-
-ntp:  # ntp pools and servers chrony config
-  servers: []
-  pools: []
 
 sshTrustedUserCAKeys:
   # Taken from https://vault.operations.giantswarm.io/v1/ssh/public_key


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR adapts `values.yaml` and the template to match the values schema, where the NTP settings are placed within the `.network` object.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.
