### PR TITLE
Add info on breaking change and provide yq script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**Info on breaking changes:** This release makes incompatible changes to the values schema. See details for info on how to migrate.
+
+<details>
+<summary>How to migrate from 0.9.0</summary>
+
+To migrate values from cluster-cloud-director 0.9.0, we provide below [yq](https://mikefarah.gitbook.io/yq/) script, which assumes your values (not a ConfigMap!) are available in the file `values.yaml`. Note that the file will be overwritten.
+
+```bash
+yq eval --inplace '
+  with(select(.ntp != null); .network.ntp = .ntp) |
+  del(.ntp)
+' ./values.yaml
+```
+
+</details>
+
 ### Fixed
 
-- Fix `values.yaml` to set NTP settings in `.network.ntp` and adapt template.
+- :boom: **Breaking:** Adapt `values.yaml` to align with `values.schema.json` and set NTP settings in `.network.ntp` and adapt template.
 
 ## [0.9.0] - 2023-04-05
 


### PR DESCRIPTION
Following up to https://github.com/giantswarm/cluster-cloud-director/pull/132

This PR adds info and a migration script to the changelog.

We have first done this in this way in cluster-aws [here](https://github.com/giantswarm/cluster-aws/blob/v0.30.0/CHANGELOG.md#0280---2023-03-23).

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.
