### PR TITLE
Bump cloud-provider-cloud-director app to 0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ yq eval --inplace '
 
 - Set `/var/lib/kubelet` permissions to `0750` to fix `node-exporter` issue.
 
+### Changed
+
+- Bump `cloud-provider-cloud-director` to `0.2.7` to inject ClusterID to NamedDisks.
+
 ### Fixed
 
 - :boom: **Breaking:** Adapt `values.yaml` to align with `values.schema.json` and set NTP settings in `.network.ntp` and adapt template.

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: cloud-provider-cloud-director
-      version: 0.2.6
+      version: 0.2.7
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default


### PR DESCRIPTION
Bump cloud-provider-cloud-director app to 0.2.7

### Testing
- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.
