### PR TITLE
Normalize values schema according to `schemalint` v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add default value to schema for `.controlPlane.replicas`.
+
 ### Changed
 
 - Normalize values schema according to `schemalint` v2.
+
+### Fixed
+
+- Values schema: remove invalid key `replicas` from `.controlPlane.replicas`
+
 
 ## [0.11.1] - 2023-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Normalize values schema according to `schemalint` v2.
+
 ## [0.11.1] - 2023-05-25
 
 ### Fixed

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -534,7 +534,7 @@
                     "type": "integer",
                     "title": "Number of nodes",
                     "description": "Number of control plane instances to create. Must be an odd number.",
-                    "replicas": 0
+                    "default": 0
                 },
                 "resourceRatio": {
                     "type": "integer",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -1,541 +1,448 @@
 {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
         "catalog": {
+            "type": "string",
+            "title": "Catalog",
             "description": "VCD catalog in which the template is stored.",
             "examples": [
                 "giantswarm"
-            ],
-            "title": "Catalog",
-            "type": "string"
+            ]
         },
         "cidrBlocks": {
+            "type": "array",
             "items": {
+                "type": "string",
                 "description": "IPv4 address range, in CIDR notation.",
-                 "examples": [
-                     "10.244.0.0/16"
-                 ],
-                 "type": "string"
+                "examples": [
+                    "10.244.0.0/16"
+                ]
             },
-            "minItems": 1,
             "maxItems": 1,
-            "type": "array"
+            "minItems": 1
         },
         "diskSizeGB": {
+            "type": "integer",
+            "title": "Node disk size in GB",
             "description": "Change size of the nodes OS disk.",
             "examples": [
                 30
-            ],
-            "title": "Node disk size in GB",
-            "type": "integer"
+            ]
         },
         "nodeLabels": {
+            "type": "array",
             "items": {
+                "type": "string",
+                "title": "Custom node label",
                 "examples": [
                     "key=value"
                 ],
-                "pattern": "^[A-Za-z0-9-_\\./]{1,63}=[A-Za-z0-9-_\\.]{0,63}$",
-                "title": "Custom node label",
-                "type": "string"
-            },
-            "type": "array"
+                "pattern": "^[A-Za-z0-9-_\\./]{1,63}=[A-Za-z0-9-_\\.]{0,63}$"
+            }
         },
         "nodeTaints": {
+            "type": "array",
             "items": {
+                "type": "object",
+                "title": "Custom node taint",
+                "required": [
+                    "key",
+                    "effect"
+                ],
                 "properties": {
                     "effect": {
+                        "type": "string",
                         "description": "One of NoSchedule, PreferNoSchedule or NoExecute",
                         "enum": [
                             "NoSchedule",
                             "PreferNoSchedule",
                             "NoExecute"
-                        ],
-                        "type": "string"
+                        ]
                     },
                     "key": {
+                        "type": "string",
                         "description": "Name of the label on a node",
-                        "minLength": 1,
-                        "type": "string"
+                        "minLength": 1
                     },
                     "value": {
-                        "description": "value of the label identified by the key",
-                        "type": "string"
+                        "type": "string",
+                        "description": "value of the label identified by the key"
                     }
-                },
-                "required": [
-                    "key",
-                    "effect"
-                ],
-                "title": "Custom node taint",
-                "type": "object"
-            },
-            "type": "array"
+                }
+            }
         },
         "placementPolicy": {
-            "title": "Placement policy",
-            "type": "string"
+            "type": "string",
+            "title": "Placement policy"
         },
         "sizingPolicy": {
+            "type": "string",
+            "title": "Sizing policy",
             "examples": [
                 "m1.medium"
-            ],
-            "title": "Sizing policy",
-            "type": "string"
+            ]
         },
         "storageProfile": {
-            "title": "Storage profile",
-            "type": "string"
+            "type": "string",
+            "title": "Storage profile"
         },
         "template": {
+            "type": "string",
+            "title": "Template",
             "description": "Template used to create the node VM.",
             "examples": [
                 "ubuntu-2004-kube-v1.22.5"
-            ],
-            "title": "Template",
-            "type": "string"
+            ]
         }
     },
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": [
+        "apiServer",
+        "baseDomain",
+        "controllerManager",
+        "cloudDirector",
+        "controlPlane",
+        "connectivity",
+        "nodeClasses",
+        "nodePools",
+        "organization",
+        "userContext"
+    ],
     "properties": {
         "apiServer": {
-            "properties": {
-                "certSANs": {
-                    "default": [],
-                    "description": "Alternative names to encode in the API server's certificate.",
-                    "items": {
-                        "title": "SAN",
-                        "type": "string"
-                    },
-                    "title": "Subject alternative names (SAN)",
-                    "type": "array"
-                },
-                "enableAdmissionPlugins": {
-                    "default": "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook",
-                    "description": "Comma-separated list of admission plugins to enable.",
-                    "title": "Admission plugins",
-                    "type": "string"
-                },
-                "featureGates": {
-                    "default": "TTLAfterFinished=true",
-                    "description": "Enabled feature gates, as a comma-separated list.",
-                    "title": "Feature gates",
-                    "type": "string"
-                }
-            },
+            "type": "object",
+            "title": "Kubernetes API server",
             "required": [
                 "enableAdmissionPlugins",
                 "featureGates"
             ],
-            "title": "Kubernetes API server",
-            "type": "object"
+            "properties": {
+                "certSANs": {
+                    "type": "array",
+                    "title": "Subject alternative names (SAN)",
+                    "description": "Alternative names to encode in the API server's certificate.",
+                    "items": {
+                        "type": "string",
+                        "title": "SAN"
+                    },
+                    "default": []
+                },
+                "enableAdmissionPlugins": {
+                    "type": "string",
+                    "title": "Admission plugins",
+                    "description": "Comma-separated list of admission plugins to enable.",
+                    "default": "NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"
+                },
+                "featureGates": {
+                    "type": "string",
+                    "title": "Feature gates",
+                    "description": "Enabled feature gates, as a comma-separated list.",
+                    "default": "TTLAfterFinished=true"
+                }
+            }
         },
         "baseDomain": {
-            "default": "k8s.test",
+            "type": "string",
             "title": "Base DNS domain",
-            "type": "string"
+            "default": "k8s.test"
         },
         "cloudDirector": {
-            "properties": {
-                "org": {
-                    "default": "",
-                    "description": "VCD organization name.",
-                    "title": "Organization",
-                    "type": "string"
-                },
-                "ovdc": {
-                    "default": "",
-                    "description": "Name of the organization virtual datacenter (OvDC) to create this cluster in.",
-                    "title": "OvDC name",
-                    "type": "string"
-                },
-                "ovdcNetwork": {
-                    "default": "",
-                    "description": "VCD network to connect VMs.",
-                    "title": "OvDC network",
-                    "type": "string"
-                },
-                "site": {
-                    "default": "",
-                    "description": "VCD endpoint URL in the format https://VCD_HOST, without trailing slash.",
-                    "title": "Endpoint",
-                    "type": "string"
-                }
-            },
+            "type": "object",
+            "title": "Cloud Director",
             "required": [
                 "org",
                 "ovdc",
                 "ovdcNetwork",
                 "site"
             ],
-            "title": "Cloud Director",
-            "type": "object"
+            "properties": {
+                "org": {
+                    "type": "string",
+                    "title": "Organization",
+                    "description": "VCD organization name.",
+                    "default": ""
+                },
+                "ovdc": {
+                    "type": "string",
+                    "title": "OvDC name",
+                    "description": "Name of the organization virtual datacenter (OvDC) to create this cluster in.",
+                    "default": ""
+                },
+                "ovdcNetwork": {
+                    "type": "string",
+                    "title": "OvDC network",
+                    "description": "VCD network to connect VMs.",
+                    "default": ""
+                },
+                "site": {
+                    "type": "string",
+                    "title": "Endpoint",
+                    "description": "VCD endpoint URL in the format https://VCD_HOST, without trailing slash.",
+                    "default": ""
+                }
+            }
         },
         "cloudProvider": {
-            "properties": {
-                "enableVirtualServiceSharedIP": {
-                    "default": true,
-                    "description": "If enabled, multiple virtual services can share the same virtual IP address.",
-                    "title": "Enable sharing of IPs in virtual services",
-                    "type": "boolean"
-                },
-                "oneArm": {
-                    "description": "If enabled, use an internal IP for the virtual service with a NAT rule to expose the external IP. Otherwise the virtual service will be exposed directly with the external IP.",
-                    "properties": {
-                        "enabled": {
-                            "default": false,
-                            "title": "Enable",
-                            "type": "boolean"
-                        }
-                    },
-                    "title": "One-arm",
-                    "type": "object"
-                }
-            },
+            "type": "object",
+            "title": "Cloud provider interface (CPI)",
             "required": [
                 "enableVirtualServiceSharedIP",
                 "oneArm"
             ],
-            "title": "Cloud provider interface (CPI)",
-            "type": "object"
+            "properties": {
+                "enableVirtualServiceSharedIP": {
+                    "type": "boolean",
+                    "title": "Enable sharing of IPs in virtual services",
+                    "description": "If enabled, multiple virtual services can share the same virtual IP address.",
+                    "default": true
+                },
+                "oneArm": {
+                    "type": "object",
+                    "title": "One-arm",
+                    "description": "If enabled, use an internal IP for the virtual service with a NAT rule to expose the external IP. Otherwise the virtual service will be exposed directly with the external IP.",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "title": "Enable",
+                            "default": false
+                        }
+                    }
+                }
+            }
         },
         "cluster": {
+            "type": "object",
+            "title": "Cluster",
             "properties": {
                 "parentUid": {
-                    "default": "",
-                    "description": "If set, create the cluster from a specific management cluster associated with this UID.",
+                    "type": "string",
                     "title": "Management cluster UID",
-                    "type": "string"
+                    "description": "If set, create the cluster from a specific management cluster associated with this UID.",
+                    "default": ""
                 },
                 "rdeId": {
-                    "default": "",
-                    "description": "This cluster's entity ID in the VCD API.",
+                    "type": "string",
                     "title": "RDE ID",
-                    "type": "string"
+                    "description": "This cluster's entity ID in the VCD API.",
+                    "default": ""
                 },
                 "useAsManagementCluster": {
-                    "default": false,
+                    "type": "boolean",
                     "title": "Display as management cluster",
-                    "type": "boolean"
+                    "default": false
                 }
-            },
-            "title": "Cluster",
-            "type": "object"
+            }
         },
         "clusterDescription": {
-            "default": "",
-            "description": "User-friendly description of the cluster's purpose.",
+            "type": "string",
             "title": "Cluster description",
-            "type": "string"
+            "description": "User-friendly description of the cluster's purpose.",
+            "default": ""
         },
         "clusterLabels": {
-            "default": {},
-            "description": "Used for adding configurable labels to the cluster resource.",
+            "type": "object",
             "title": "Cluster labels",
-            "type": "object"
+            "description": "Used for adding configurable labels to the cluster resource.",
+            "default": {}
         },
         "connectivity": {
+            "type": "object",
+            "title": "Connectivity",
             "description": "Configurations related to cluster connectivity such as container registries.",
+            "required": [
+                "containerRegistries",
+                "network"
+            ],
             "properties": {
                 "containerRegistries": {
+                    "type": "object",
+                    "title": "Container registries",
+                    "description": "Endpoints and credentials configuration for container registries.",
                     "additionalProperties": {
+                        "type": "array",
                         "items": {
-                            "properties": {
-                                "credentials": {
-                                    "description": "Credentials for the endpoint.",
-                                    "properties": {
-                                        "auth": {
-                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password.",
-                                            "title": "Auth",
-                                            "type": "string"
-                                        },
-                                        "identitytoken": {
-                                            "description": "Used to authenticate the user and obtain an access token for the registry.",
-                                            "title": "Identity token",
-                                            "type": "string"
-                                        },
-                                        "password": {
-                                            "description": "Used to authenticate for the registry with username/password.",
-                                            "title": "Password",
-                                            "type": "string"
-                                        },
-                                        "username": {
-                                            "description": "Used to authenticate for the registry with username/password.",
-                                            "title": "Username",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "title": "Credentials",
-                                    "type": "object"
-                                },
-                                "endpoint": {
-                                    "description": "Endpoint for the container registry.",
-                                    "title": "Endpoint",
-                                    "type": "string"
-                                }
-                            },
+                            "type": "object",
                             "required": [
                                 "endpoint"
                             ],
-                            "type": "object"
-                        },
-                        "type": "array"
-                    },
-                    "default": {},
-                    "description": "Endpoints and credentials configuration for container registries.",
-                    "title": "Container registries",
-                    "type": "object"
-                },
-                "network": {
-                    "properties": {
-                        "controlPlaneEndpoint": {
-                            "description": "Kubernetes API endpoint.",
                             "properties": {
-                                "host": {
-                                    "default": "",
-                                    "title": "Host",
-                                    "type": "string"
-                                },
-                                "port": {
-                                    "default": "",
-                                    "title": "Port number",
-                                    "type": "integer"
-                                }
-                            },
-                            "title": "Control plane endpoint",
-                            "type": "object"
-                        },
-                        "extraOvdcNetworks": {
-                            "default": [],
-                            "description": "OVDC networks to attach VMs to, additionally.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "title": "Extra OVDC networks",
-                            "type": "array"
-                        },
-                        "loadBalancers": {
-                            "properties": {
-                                "vipSubnet": {
-                                    "default": "",
-                                    "description": "Virtual IP CIDR for the external network.",
-                                    "title": "Virtual IP subnet",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "vipSubnet"
-                            ],
-                            "title": "Load Balancers",
-                            "type": "object"
-                        },
-                        "ntp": {
-                            "description": "Servers/pools to synchronize this cluster's clocks with.",
-                            "properties": {
-                                "pools": {
-                                    "default": [],
-                                    "items": {
-                                        "examples": [
-                                            "ntp.ubuntu.com"
-                                        ],
-                                        "title": "Pool",
-                                        "type": "string"
-                                    },
-                                    "title": "Pools",
-                                    "type": "array"
-                                },
-                                "servers": {
-                                    "default": [],
-                                    "items": {
-                                        "title": "Server",
-                                        "type": "string"
-                                    },
-                                    "title": "Servers",
-                                    "type": "array"
-                                }
-                            },
-                            "title": "Time synchronization (NTP)",
-                            "type": "object"
-                        },
-                        "pods": {
-                            "properties": {
-                                "cidrBlocks": {
-                                    "$ref": "#/$defs/cidrBlocks",
-                                    "default": "10.244.0.0/16",
-                                    "title": "Pod subnets"
-                                }
-                            },
-                            "required": [
-                                "cidrBlocks"
-                            ],
-                            "title": "Pods",
-                            "type": "object"
-                        },
-                        "services": {
-                            "properties": {
-                                "cidrBlocks": {
-                                    "$ref": "#/$defs/cidrBlocks",
-                                    "default": "172.31.0.0/16",
-                                    "title": "Service subnets"
-                                }
-                            },
-                            "required": [
-                                "cidrBlocks"
-                            ],
-                            "title": "Services",
-                            "type": "object"
-                        },
-                        "staticRoutes": {
-                            "default": [],
-                            "items": {
-                                "properties": {
-                                    "destination": {
-                                        "description": "IPv4 address range in CIDR notation.",
-                                        "examples": [
-                                            "10.128.0.0/16"
-                                        ],
-                                        "title": "Destination",
-                                        "type": "string"
-                                    },
-                                    "via": {
-                                        "format": "ipv4",
-                                        "title": "Via",
-                                        "type": "string"
+                                "credentials": {
+                                    "type": "object",
+                                    "title": "Credentials",
+                                    "description": "Credentials for the endpoint.",
+                                    "properties": {
+                                        "auth": {
+                                            "type": "string",
+                                            "title": "Auth",
+                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+                                        },
+                                        "identitytoken": {
+                                            "type": "string",
+                                            "title": "Identity token",
+                                            "description": "Used to authenticate the user and obtain an access token for the registry."
+                                        },
+                                        "password": {
+                                            "type": "string",
+                                            "title": "Password",
+                                            "description": "Used to authenticate for the registry with username/password."
+                                        },
+                                        "username": {
+                                            "type": "string",
+                                            "title": "Username",
+                                            "description": "Used to authenticate for the registry with username/password."
+                                        }
                                     }
                                 },
-                                "required": [
-                                    "destination",
-                                    "via"
-                                ],
-                                "type": "object"
-                            },
-                            "title": "Static routes",
-                            "type": "array"
+                                "endpoint": {
+                                    "type": "string",
+                                    "title": "Endpoint",
+                                    "description": "Endpoint for the container registry."
+                                }
+                            }
                         }
                     },
+                    "default": {}
+                },
+                "network": {
+                    "type": "object",
+                    "title": "Network",
                     "required": [
                         "loadBalancers",
                         "pods",
                         "services"
                     ],
-                    "title": "Network",
-                    "type": "object"
+                    "properties": {
+                        "controlPlaneEndpoint": {
+                            "type": "object",
+                            "title": "Control plane endpoint",
+                            "description": "Kubernetes API endpoint.",
+                            "properties": {
+                                "host": {
+                                    "type": "string",
+                                    "title": "Host",
+                                    "default": ""
+                                },
+                                "port": {
+                                    "type": "integer",
+                                    "title": "Port number",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "extraOvdcNetworks": {
+                            "type": "array",
+                            "title": "Extra OVDC networks",
+                            "description": "OVDC networks to attach VMs to, additionally.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": []
+                        },
+                        "loadBalancers": {
+                            "type": "object",
+                            "title": "Load Balancers",
+                            "required": [
+                                "vipSubnet"
+                            ],
+                            "properties": {
+                                "vipSubnet": {
+                                    "type": "string",
+                                    "title": "Virtual IP subnet",
+                                    "description": "Virtual IP CIDR for the external network.",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "ntp": {
+                            "type": "object",
+                            "title": "Time synchronization (NTP)",
+                            "description": "Servers/pools to synchronize this cluster's clocks with.",
+                            "properties": {
+                                "pools": {
+                                    "type": "array",
+                                    "title": "Pools",
+                                    "items": {
+                                        "type": "string",
+                                        "title": "Pool",
+                                        "examples": [
+                                            "ntp.ubuntu.com"
+                                        ]
+                                    },
+                                    "default": []
+                                },
+                                "servers": {
+                                    "type": "array",
+                                    "title": "Servers",
+                                    "items": {
+                                        "type": "string",
+                                        "title": "Server"
+                                    },
+                                    "default": []
+                                }
+                            }
+                        },
+                        "pods": {
+                            "type": "object",
+                            "title": "Pods",
+                            "required": [
+                                "cidrBlocks"
+                            ],
+                            "properties": {
+                                "cidrBlocks": {
+                                    "$ref": "#/$defs/cidrBlocks",
+                                    "title": "Pod subnets",
+                                    "default": "10.244.0.0/16"
+                                }
+                            }
+                        },
+                        "services": {
+                            "type": "object",
+                            "title": "Services",
+                            "required": [
+                                "cidrBlocks"
+                            ],
+                            "properties": {
+                                "cidrBlocks": {
+                                    "$ref": "#/$defs/cidrBlocks",
+                                    "title": "Service subnets",
+                                    "default": "172.31.0.0/16"
+                                }
+                            }
+                        },
+                        "staticRoutes": {
+                            "type": "array",
+                            "title": "Static routes",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "destination",
+                                    "via"
+                                ],
+                                "properties": {
+                                    "destination": {
+                                        "type": "string",
+                                        "title": "Destination",
+                                        "description": "IPv4 address range in CIDR notation.",
+                                        "examples": [
+                                            "10.128.0.0/16"
+                                        ]
+                                    },
+                                    "via": {
+                                        "type": "string",
+                                        "title": "Via",
+                                        "format": "ipv4"
+                                    }
+                                }
+                            },
+                            "default": []
+                        }
+                    }
                 }
-            },
-            "required": [
-                "containerRegistries",
-                "network"
-            ],
-            "title": "Connectivity",
-            "type": "object"
+            }
         },
         "controlPlane": {
-            "properties": {
-                "catalog": {
-                    "$ref": "#/$defs/catalog",
-                    "default": "",
-                    "description": "VCD catalog where the VM template is stored.",
-                    "title": "Catalog"
-                },
-                "customNodeLabels": {
-                    "$ref": "#/$defs/nodeLabels",
-                    "default": [],
-                    "title": "Custom node labels"
-                },
-                "diskSizeGB": {
-                    "$ref": "#/$defs/diskSizeGB",
-                    "title": "Disk size (GB)"
-                },
-                "dns": {
-                    "properties": {
-                        "imageRepository": {
-                            "default": "projects.registry.vmware.com/tkg",
-                            "examples": [
-                                "projects.registry.vmware.com/tkg"
-                            ],
-                            "title": "Repository",
-                            "type": "string"
-                        },
-                        "imageTag": {
-                            "default": "v1.7.0_vmware.12",
-                            "examples": [
-                                "v1.7.0_vmware.12"
-                            ],
-                            "title": "Tag",
-                            "type": "string"
-                        }
-                    },
-                    "title": "DNS container image",
-                    "type": "object"
-                },
-                "etcd": {
-                    "properties": {
-                        "imageRepository": {
-                            "default": "giantswarm",
-                            "examples": [
-                                "giantswarm"
-                            ],
-                            "title": "Repository",
-                            "type": "string"
-                        },
-                        "imageTag": {
-                            "default": "3.5.4-0-k8s",
-                            "examples": [
-                                "3.5.4-0-k8s"
-                            ],
-                            "title": "Tag",
-                            "type": "string"
-                        }
-                    },
-                    "title": "Etcd container image",
-                    "type": "object"
-                },
-                "image": {
-                    "properties": {
-                        "repository": {
-                            "default": "projects.registry.vmware.com/tkg",
-                            "examples": [
-                                "projects.registry.vmware.com/tkg"
-                            ],
-                            "title": "Repository",
-                            "type": "string"
-                        }
-                    },
-                    "title": "Node container image",
-                    "type": "object"
-                },
-                "placementPolicy": {
-                    "$ref": "#/$defs/placementPolicy",
-                    "default": "",
-                    "title": "VM placement policy"
-                },
-                "replicas": {
-                    "description": "Number of control plane instances to create. Must be an odd number.",
-                    "replicas": 0,
-                    "title": "Number of nodes",
-                    "type": "integer"
-                },
-                "resourceRatio": {
-                    "default": 8,
-                    "description": "Ratio between node resources and apiserver resource requests.",
-                    "minimum": 2,
-                    "title": "Resource ratio",
-                    "type": "integer"
-                },
-                "sizingPolicy": {
-                    "$ref": "#/$defs/sizingPolicy",
-                    "default": "",
-                    "title": "Sizing policy"
-                },
-                "storageProfile": {
-                    "$ref": "#/$defs/storageProfile",
-                    "default": "",
-                    "title": "Storage profile"
-                },
-                "template": {
-                    "$ref": "#/$defs/template",
-                    "default": "",
-                    "title": "VM template"
-                }
-            },
+            "type": "object",
+            "title": "Control plane",
             "required": [
                 "catalog",
                 "template",
@@ -544,60 +451,170 @@
                 "etcd",
                 "resourceRatio"
             ],
-            "title": "Control plane",
-            "type": "object"
+            "properties": {
+                "catalog": {
+                    "$ref": "#/$defs/catalog",
+                    "title": "Catalog",
+                    "description": "VCD catalog where the VM template is stored.",
+                    "default": ""
+                },
+                "customNodeLabels": {
+                    "$ref": "#/$defs/nodeLabels",
+                    "title": "Custom node labels",
+                    "default": []
+                },
+                "diskSizeGB": {
+                    "$ref": "#/$defs/diskSizeGB",
+                    "title": "Disk size (GB)"
+                },
+                "dns": {
+                    "type": "object",
+                    "title": "DNS container image",
+                    "properties": {
+                        "imageRepository": {
+                            "type": "string",
+                            "title": "Repository",
+                            "examples": [
+                                "projects.registry.vmware.com/tkg"
+                            ],
+                            "default": "projects.registry.vmware.com/tkg"
+                        },
+                        "imageTag": {
+                            "type": "string",
+                            "title": "Tag",
+                            "examples": [
+                                "v1.7.0_vmware.12"
+                            ],
+                            "default": "v1.7.0_vmware.12"
+                        }
+                    }
+                },
+                "etcd": {
+                    "type": "object",
+                    "title": "Etcd container image",
+                    "properties": {
+                        "imageRepository": {
+                            "type": "string",
+                            "title": "Repository",
+                            "examples": [
+                                "giantswarm"
+                            ],
+                            "default": "giantswarm"
+                        },
+                        "imageTag": {
+                            "type": "string",
+                            "title": "Tag",
+                            "examples": [
+                                "3.5.4-0-k8s"
+                            ],
+                            "default": "3.5.4-0-k8s"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "title": "Node container image",
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "title": "Repository",
+                            "examples": [
+                                "projects.registry.vmware.com/tkg"
+                            ],
+                            "default": "projects.registry.vmware.com/tkg"
+                        }
+                    }
+                },
+                "placementPolicy": {
+                    "$ref": "#/$defs/placementPolicy",
+                    "title": "VM placement policy",
+                    "default": ""
+                },
+                "replicas": {
+                    "type": "integer",
+                    "title": "Number of nodes",
+                    "description": "Number of control plane instances to create. Must be an odd number.",
+                    "replicas": 0
+                },
+                "resourceRatio": {
+                    "type": "integer",
+                    "title": "Resource ratio",
+                    "description": "Ratio between node resources and apiserver resource requests.",
+                    "default": 8,
+                    "minimum": 2
+                },
+                "sizingPolicy": {
+                    "$ref": "#/$defs/sizingPolicy",
+                    "title": "Sizing policy",
+                    "default": ""
+                },
+                "storageProfile": {
+                    "$ref": "#/$defs/storageProfile",
+                    "title": "Storage profile",
+                    "default": ""
+                },
+                "template": {
+                    "$ref": "#/$defs/template",
+                    "title": "VM template",
+                    "default": ""
+                }
+            }
         },
         "controllerManager": {
+            "type": "object",
+            "title": "Controller manager",
+            "required": [
+                "featureGates"
+            ],
             "properties": {
                 "featureGates": {
-                    "default": "ExpandPersistentVolumes=true,TTLAfterFinished=true",
+                    "type": "string",
+                    "title": "Feature gates",
                     "description": "Comma-separated list of feature gates.",
                     "examples": [
                         "ExpandPersistentVolumes=true,TTLAfterFinished=true"
                     ],
-                    "title": "Feature gates",
-                    "type": "string"
+                    "default": "ExpandPersistentVolumes=true,TTLAfterFinished=true"
                 }
-            },
-            "required": [
-                "featureGates"
-            ],
-            "title": "Controller manager",
-            "type": "object"
+            }
         },
         "includeClusterResourceSet": {
-            "title": "Include ClusterResourceSet",
-            "type": "string"
+            "type": "string",
+            "title": "Include ClusterResourceSet"
         },
         "kubectlImage": {
+            "type": "object",
+            "title": "Kubectl image",
             "description": "Used by cluster-shared library chart to configure coredns in-cluster.",
             "properties": {
                 "name": {
-                    "default": "giantswarm/kubectl",
+                    "type": "string",
                     "title": "Repository",
-                    "type": "string"
+                    "default": "giantswarm/kubectl"
                 },
                 "registry": {
-                    "default": "quay.io",
+                    "type": "string",
                     "title": "Registry",
-                    "type": "string"
+                    "default": "quay.io"
                 },
                 "tag": {
-                    "default": "1.23.5",
+                    "type": "string",
                     "title": "Tag",
-                    "type": "string"
+                    "default": "1.23.5"
                 }
-            },
-            "title": "Kubectl image",
-            "type": "object"
+            }
         },
         "kubernetesVersion": {
-            "default": "",
+            "type": "string",
             "title": "Kubernetes version",
-            "type": "string"
+            "default": ""
         },
         "nodeClasses": {
+            "type": "object",
+            "title": "Node classes",
+            "description": "Re-usable node configuration.",
             "additionalProperties": {
+                "type": "object",
                 "properties": {
                     "catalog": {
                         "$ref": "#/$defs/catalog"
@@ -623,189 +640,172 @@
                     "template": {
                         "$ref": "#/$defs/template"
                     }
-                },
-                "type": "object"
-            },
-            "default": {},
-            "description": "Re-usable node configuration.",
-            "title": "Node classes",
-            "type": "object"
-        },
-        "nodePools": {
-            "additionalProperties": {
-                "properties": {
-                    "class": {
-                        "title": "Node class",
-                        "type": "string"
-                    },
-                    "replicas": {
-                        "minimum": 1,
-                        "type": "integer"
-                    }
-                },
-                "type": "object"
-            },
-            "default": {},
-            "description": "Groups of worker nodes with identical configuration.",
-            "title": "Node pools",
-            "type": "object"
-        },
-        "oidc": {
-            "properties": {
-                "caFile": {
-                    "default": "",
-                    "description": "Path to identity provider's CA certificate in PEM format.",
-                    "title": "Certificate authority file",
-                    "type": "string"
-                },
-                "clientId": {
-                    "default": "",
-                    "description": "OIDC client identifier to identify with.",
-                    "title": "Client ID",
-                    "type": "string"
-                },
-                "groupsClaim": {
-                    "default": "",
-                    "description": "Name of the identity token claim bearing the user's group memberships.",
-                    "title": "Groups claim",
-                    "type": "string"
-                },
-                "issuerUrl": {
-                    "default": "",
-                    "description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part.",
-                    "title": "Issuer URL",
-                    "type": "string"
-                },
-                "usernameClaim": {
-                    "default": "",
-                    "description": "Name of the identity token claim bearing the unique user identifier.",
-                    "title": "Username claim",
-                    "type": "string"
-                },
-                "usernamePrefix": {
-                    "default": "",
-                    "description": "Prefix prepended to username values to prevent clashes with existing names.",
-                    "title": "Username prefix",
-                    "type": "string"
                 }
             },
+            "default": {}
+        },
+        "nodePools": {
+            "type": "object",
+            "title": "Node pools",
+            "description": "Groups of worker nodes with identical configuration.",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "class": {
+                        "type": "string",
+                        "title": "Node class"
+                    },
+                    "replicas": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            },
+            "default": {}
+        },
+        "oidc": {
+            "type": "object",
+            "title": "OIDC authentication",
             "required": [
                 "clientId",
                 "groupsClaim",
                 "issuerUrl",
                 "usernameClaim"
             ],
-            "title": "OIDC authentication",
-            "type": "object"
+            "properties": {
+                "caFile": {
+                    "type": "string",
+                    "title": "Certificate authority file",
+                    "description": "Path to identity provider's CA certificate in PEM format.",
+                    "default": ""
+                },
+                "clientId": {
+                    "type": "string",
+                    "title": "Client ID",
+                    "description": "OIDC client identifier to identify with.",
+                    "default": ""
+                },
+                "groupsClaim": {
+                    "type": "string",
+                    "title": "Groups claim",
+                    "description": "Name of the identity token claim bearing the user's group memberships.",
+                    "default": ""
+                },
+                "issuerUrl": {
+                    "type": "string",
+                    "title": "Issuer URL",
+                    "description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part.",
+                    "default": ""
+                },
+                "usernameClaim": {
+                    "type": "string",
+                    "title": "Username claim",
+                    "description": "Name of the identity token claim bearing the unique user identifier.",
+                    "default": ""
+                },
+                "usernamePrefix": {
+                    "type": "string",
+                    "title": "Username prefix",
+                    "description": "Prefix prepended to username values to prevent clashes with existing names.",
+                    "default": ""
+                }
+            }
         },
         "organization": {
-            "default": "",
+            "type": "string",
             "title": "Organization",
-            "type": "string"
+            "default": ""
         },
         "osUsers": {
+            "type": "array",
+            "title": "OS Users",
+            "description": "Configuration for OS users in cluster nodes.",
+            "items": {
+                "type": "object",
+                "title": "User",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "Username of the user."
+                    }
+                }
+            },
             "default": [
                 {
                     "name": "giantswarm",
                     "sudo": "ALL=(ALL) NOPASSWD:ALL"
                 }
-            ],
-            "description": "Configuration for OS users in cluster nodes.",
-            "items": {
-                "properties": {
-                    "name": {
-                        "description": "Username of the user.",
-                        "title": "Name",
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "name"
-                ],
-                "title": "User",
-                "type": "object"
-            },
-            "title": "OS Users",
-            "type": "array"
+            ]
         },
         "proxy": {
+            "type": "object",
+            "title": "Proxy",
             "description": "Whether/how outgoing traffic is routed through proxy servers.",
             "properties": {
                 "enabled": {
-                    "default": false,
+                    "type": "boolean",
                     "title": "Enable",
-                    "type": "boolean"
+                    "default": false
                 },
                 "secretName": {
-                    "default": "",
-                    "description": "Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables.",
+                    "type": "string",
                     "title": "Secret name",
-                    "type": "string"
+                    "description": "Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables.",
+                    "default": ""
                 }
-            },
-            "title": "Proxy",
-            "type": "object"
+            }
         },
         "servicePriority": {
-            "default": "highest",
+            "type": "string",
+            "title": "Service priority",
             "description": "The relative importance of this cluster.",
             "enum": [
                 "lowest",
                 "medium",
                 "highest"
             ],
-            "title": "Service priority",
-            "type": "string"
+            "default": "highest"
         },
         "sshTrustedUserCAKeys": {
-            "default": [
-                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
-            ],
+            "type": "array",
+            "title": "Trusted SSH cert issuers",
             "description": "CA certificates of issuers that are trusted to sign SSH user certificates.",
             "items": {
                 "type": "string"
             },
-            "title": "Trusted SSH cert issuers",
-            "type": "array"
+            "default": [
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
+            ]
         },
         "userContext": {
+            "type": "object",
+            "title": "User context",
             "properties": {
                 "secretRef": {
+                    "type": "object",
+                    "title": "Secret",
                     "properties": {
                         "secretName": {
-                            "default": "",
-                            "description": "Name of the pre-existing secret containing the credentials of the VCD user.",
+                            "type": "string",
                             "title": "Name",
-                            "type": "string"
+                            "description": "Name of the pre-existing secret containing the credentials of the VCD user.",
+                            "default": ""
                         }
-                    },
-                    "title": "Secret",
-                    "type": "object"
+                    }
                 }
-            },
-            "title": "User context",
-            "type": "object"
+            }
         },
         "vmNamingTemplate": {
+            "type": "string",
+            "title": "VM naming template",
             "description": "Go template to generate VM names based on machine and vcdMachine CRs.",
             "examples": [
                 "mytenant-{{.machine.Name |sha256sum | trunc 7}}"
-            ],
-            "title": "VM naming template",
-            "type": "string"
+            ]
         }
-    },
-    "required": [
-        "apiServer",
-        "baseDomain",
-        "controllerManager",
-        "cloudDirector",
-        "controlPlane",
-        "connectivity",
-        "nodeClasses",
-        "nodePools",
-        "organization",
-        "userContext"
-    ],
-    "type": "object"
+    }
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

With `schemalint` major version 2, the order of keys in `schemalint normalize` has changed to be more human-friendly. This PR updates the schema accordingly. No logical changes have been made.

Command used:

```
schemalint normalize helm/cluster-cloud-director/values.schema.json \
  -o helm/cluster-cloud-director/values.schema.json \
  --force
```