### PR TITLE
Remove invalid key in .controlPlane.replicas, add default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix connectivity key in vcdcluster template.
+- Values schema: remove invalid property from .controlPlane.replicas object
 
 ## [0.11.0] - 2023-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add default value to schema for `.controlPlane.replicas`.
+
 ### Changed
 
 - Normalize values schema according to `schemalint` v2.
+
+### Fixed
+
+- Values schema: remove invalid key `replicas` from `.controlPlane.replicas`
+
 
 ## [0.11.1] - 2023-05-25
 
 ### Fixed
 
 - Fix connectivity key in vcdcluster template.
-- Values schema: remove invalid property from .controlPlane.replicas object
 
 ## [0.11.0] - 2023-05-23
 

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -533,8 +533,7 @@
                 "replicas": {
                     "type": "integer",
                     "title": "Number of nodes",
-                    "description": "Number of control plane instances to create. Must be an odd number.",
-                    "replicas": 0
+                    "description": "Number of control plane instances to create. Must be an odd number."
                 },
                 "resourceRatio": {
                     "type": "integer",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -533,7 +533,8 @@
                 "replicas": {
                     "type": "integer",
                     "title": "Number of nodes",
-                    "description": "Number of control plane instances to create. Must be an odd number."
+                    "description": "Number of control plane instances to create. Must be an odd number.",
+                    "default": 0
                 },
                 "resourceRatio": {
                     "type": "integer",


### PR DESCRIPTION
Towards making the values schema strictly valid (https://github.com/giantswarm/roadmap/issues/2132).

This PR fixes a mistake I made in https://github.com/giantswarm/cluster-cloud-director/pull/130 by

- removing the invalid key `replicas` from the `.controlPlane.replicas` property.
- adding the default value on `.controlPlane.replicas` (taken from values.yaml)