### PR TITLE
Move `.servicePriority` to `.metadata.servicePriority`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<details>
+<summary>How to migrate from 0.11.x</summary>
+
+To migrate values from cluster-cloud-director 0.11.x, we provide below [yq](https://mikefarah.gitbook.io/yq/) script, which assumes your values (not a ConfigMap!) are available in the file `values.yaml`. Note that the file will be overwritten.
+
+```bash
+yq eval --inplace '
+  with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
+  del(.servicePriority)
+' ./values.yaml
+```
+
+</details>
+
 ### Added
 
 - Add default value to schema for `.controlPlane.replicas`.
@@ -14,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Normalize values schema according to `schemalint` v2.
+- :boom: Breaking schema changes:
+  - `.servicePriority` moved to `.metadata.servicePriority`
 
 ### Fixed
 

--- a/examples/giantswarm-cluster/cluster_guppy_custom-node-names.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_custom-node-names.yaml
@@ -9,7 +9,8 @@ data:
     clusterDescription: test cluster configured with custom node names.
     kubernetesVersion: v1.22.9+vmware.1
     organization: multi-project
-    servicePriority: highest
+    metadata:
+      servicePriority: highest
 
     cloudDirector:
       org: giantswarm

--- a/examples/giantswarm-cluster/cluster_guppy_multi-nic.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_multi-nic.yaml
@@ -9,7 +9,8 @@ data:
     clusterDescription: test cluster with 2 nics and static route.
     kubernetesVersion: v1.22.9+vmware.1
     organization: multi-project
-    servicePriority: highest
+    metadata:
+      servicePriority: highest
 
     cloudDirector:
       org: giantswarm

--- a/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
@@ -9,7 +9,8 @@ data:
     clusterDescription: test cluster configured with http proxy.
     kubernetesVersion: v1.22.9+vmware.1
     organization: multi-project
-    servicePriority: highest
+    metadata:
+      servicePriority: highest
 
     cloudDirector:
       org: giantswarm

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
     cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
+    giantswarm.io/service-priority: {{ .Values.metadata.servicePriority | quote }}
     {{- include "labels.common" . | nindent 4 }}
     {{- range $key, $val := .Values.clusterLabels }}
     {{ $key }}: {{ $val | quote }}

--- a/helm/cluster-cloud-director/templates/cluster.yaml
+++ b/helm/cluster-cloud-director/templates/cluster.yaml
@@ -7,7 +7,7 @@ metadata:
     cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: "{{ .Values.servicePriority }}"
+    giantswarm.io/service-priority: {{ .Values.metadata.servicePriority | quote }}
     {{- include "labels.common" . | nindent 4 }}
     {{- range $key, $val := .Values.clusterLabels }}
     {{ $key }}: {{ $val | quote }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -617,20 +617,6 @@
             "type": "object",
             "title": "Metadata",
             "properties": {
-                "description": {
-                    "type": "string",
-                    "title": "Cluster description",
-                    "description": "User-friendly description of the cluster's purpose."
-                },
-                "name": {
-                    "type": "string",
-                    "title": "Cluster name",
-                    "description": "Unique identifier, cannot be changed after creation."
-                },
-                "organization": {
-                    "type": "string",
-                    "title": "Organization"
-                },
                 "servicePriority": {
                     "type": "string",
                     "title": "Service priority",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -795,17 +795,6 @@
                 }
             }
         },
-        "servicePriority": {
-            "type": "string",
-            "title": "Service priority",
-            "description": "The relative importance of this cluster.",
-            "enum": [
-                "lowest",
-                "medium",
-                "highest"
-            ],
-            "default": "highest"
-        },
         "sshTrustedUserCAKeys": {
             "type": "array",
             "title": "Trusted SSH cert issuers",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -613,6 +613,38 @@
             "title": "Kubernetes version",
             "default": ""
         },
+        "metadata": {
+            "type": "object",
+            "title": "Metadata",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "title": "Cluster description",
+                    "description": "User-friendly description of the cluster's purpose."
+                },
+                "name": {
+                    "type": "string",
+                    "title": "Cluster name",
+                    "description": "Unique identifier, cannot be changed after creation."
+                },
+                "organization": {
+                    "type": "string",
+                    "title": "Organization"
+                },
+                "servicePriority": {
+                    "type": "string",
+                    "title": "Service priority",
+                    "description": "The relative importance of this cluster.",
+                    "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
+                    "enum": [
+                        "highest",
+                        "medium",
+                        "lowest"
+                    ],
+                    "default": "highest"
+                }
+            }
+        },
         "nodeClasses": {
             "type": "object",
             "title": "Node classes",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -79,7 +79,6 @@ osUsers:
 proxy:
   enabled: false
   secretName: ""
-servicePriority: highest
 sshTrustedUserCAKeys:
   - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 userContext:

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -61,6 +61,8 @@ kubectlImage:
   registry: quay.io
   tag: 1.23.5
 kubernetesVersion: ""
+metadata:
+  servicePriority: highest
 nodeClasses: {}
 nodePools: {}
 oidc:


### PR DESCRIPTION
Toweards https://github.com/giantswarm/roadmap/issues/2132

This PR creates the root-level `.metadata` object and moves `.servicePriority` to `.metadata.servicePriority`. Templates and examples are updated accordingly.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
