### PR TITLE
Move `.clusterLabels` to `.metadata.labels`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ To migrate values from cluster-cloud-director 0.11.x, we provide below [yq](http
 
 ```bash
 yq eval --inplace '
+  with(select(.clusterLabels != null); .metadata.labels = .clusterLabels) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
+  del(.clusterLabels) |
   del(.oidc) |
   del(.servicePriority)
 ' ./values.yaml
@@ -31,6 +33,7 @@ yq eval --inplace '
 
 - Normalize values schema according to `schemalint` v2.
 - :boom: Breaking schema changes:
+  - `.clusterLabels` moved to `.metadata.labels`
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
 

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -9,9 +9,11 @@ metadata:
     cluster-apps-operator.giantswarm.io/watching: ""
     giantswarm.io/service-priority: {{ .Values.metadata.servicePriority | quote }}
     {{- include "labels.common" . | nindent 4 }}
+    {{- if .Values.metadata.labels }}
     {{- range $key, $val := .Values.metadata.labels }}
     {{ $key }}: {{ $val | quote }}
-    {{- end}}
+    {{- end }}
+    {{- end }}
 spec:
   suspend: true # It will be unsuspended by the post-install/post-upgrade hook in update-values-hook-job.yaml.
   releaseName: cloud-provider-cloud-director

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -9,7 +9,7 @@ metadata:
     cluster-apps-operator.giantswarm.io/watching: ""
     giantswarm.io/service-priority: {{ .Values.metadata.servicePriority | quote }}
     {{- include "labels.common" . | nindent 4 }}
-    {{- range $key, $val := .Values.clusterLabels }}
+    {{- range $key, $val := .Values.metadata.labels }}
     {{ $key }}: {{ $val | quote }}
     {{- end}}
 spec:

--- a/helm/cluster-cloud-director/templates/cluster.yaml
+++ b/helm/cluster-cloud-director/templates/cluster.yaml
@@ -9,9 +9,11 @@ metadata:
     cluster-apps-operator.giantswarm.io/watching: ""
     giantswarm.io/service-priority: {{ .Values.metadata.servicePriority | quote }}
     {{- include "labels.common" . | nindent 4 }}
+    {{- if .Values.metadata.labels }}
     {{- range $key, $val := .Values.metadata.labels }}
     {{ $key }}: {{ $val | quote }}
-    {{- end}}
+    {{- end }}
+    {{- end }}
 spec:
   clusterNetwork:
     pods:

--- a/helm/cluster-cloud-director/templates/cluster.yaml
+++ b/helm/cluster-cloud-director/templates/cluster.yaml
@@ -9,7 +9,7 @@ metadata:
     cluster-apps-operator.giantswarm.io/watching: ""
     giantswarm.io/service-priority: {{ .Values.metadata.servicePriority | quote }}
     {{- include "labels.common" . | nindent 4 }}
-    {{- range $key, $val := .Values.clusterLabels }}
+    {{- range $key, $val := .Values.metadata.labels }}
     {{ $key }}: {{ $val | quote }}
     {{- end}}
 spec:

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -239,12 +239,6 @@
             "description": "User-friendly description of the cluster's purpose.",
             "default": ""
         },
-        "clusterLabels": {
-            "type": "object",
-            "title": "Cluster labels",
-            "description": "Used for adding configurable labels to the cluster resource.",
-            "default": {}
-        },
         "connectivity": {
             "type": "object",
             "title": "Connectivity",
@@ -665,6 +659,20 @@
             "type": "object",
             "title": "Metadata",
             "properties": {
+                "labels": {
+                    "type": "object",
+                    "title": "Labels",
+                    "description": "These labels are added to the Kubernetes resourses defining this cluster.",
+                    "patternProperties": {
+                        "^[_-a-zA-Z0-9\\.]$": {
+                            "type": "string",
+                            "title": "Label",
+                            "maxLength": 63,
+                            "minLength": 0,
+                            "pattern": "^[_-a-zA-Z0-9\\.]$"
+                        }
+                    }
+                },
                 "servicePriority": {
                     "type": "string",
                     "title": "Service priority",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -623,6 +623,11 @@
             "type": "object",
             "title": "Metadata",
             "properties": {
+                "description": {
+                    "type": "string",
+                    "title": "Cluster description",
+                    "description": "User-friendly description of the cluster's purpose."
+                },
                 "labels": {
                     "type": "object",
                     "title": "Labels",
@@ -636,11 +641,6 @@
                             "pattern": "^[_-a-zA-Z0-9\\.]$"
                         }
                     }
-                }
-                "description": {
-                    "type": "string",
-                    "title": "Cluster description",
-                    "description": "User-friendly description of the cluster's purpose."
                 },
                 "organization": {
                     "type": "string",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -195,12 +195,6 @@
                 }
             }
         },
-        "clusterDescription": {
-            "type": "string",
-            "title": "Cluster description",
-            "description": "User-friendly description of the cluster's purpose.",
-            "default": ""
-        },
         "clusterLabels": {
             "type": "object",
             "title": "Cluster labels",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -13,7 +13,6 @@ cluster:
   parentUid: ""
   rdeId: ""
   useAsManagementCluster: false
-clusterDescription: ""
 clusterLabels: {}
 connectivity:
   containerRegistries: {}

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -19,7 +19,6 @@ cluster:
   rdeId: ""
   useAsManagementCluster: false
 clusterDescription: ""
-clusterLabels: {}
 connectivity:
   containerRegistries: {}
   network:

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -13,6 +13,8 @@ cluster:
   parentUid: ""
   rdeId: ""
   useAsManagementCluster: false
+clusterDescription: ""
+clusterLabels: {}
 connectivity:
   containerRegistries: {}
   network:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR

- moves the .clusterLabels value to .metadata.labels.
- Also the empty default value is removed.
- Compared to before, the key and value format are now more constrained to prevent inputs that are not valid [K8s labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). The key pattern is not perfect to catch all invalid label keys, but it's something.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
