### PR TITLE
Move `.organization` to `.metadata.organization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ To migrate values from cluster-cloud-director 0.11.x, we provide below [yq](http
 ```bash
 yq eval --inplace '
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
+  with(select(.organization != null); .metadata.organization = .organization) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
   del(.oidc) |
+  del(.organization) |
   del(.servicePriority)
 ' ./values.yaml
 ```
@@ -33,6 +35,7 @@ yq eval --inplace '
 - :boom: Breaking schema changes:
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
+  - `.organization` moved to `.metadata.organization`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Example of a values.yaml file for Cloud provider Ikoula with minimum input (maki
 baseDomain: "cluster.local"
 clusterDescription: "glados test cluster"
 kubernetesVersion: "v1.22.5+vmware.1"
-organization: "giantswarm"
+metadata:
+  organization: "giantswarm"
 
 cloudDirector:
   site: "https://vmware.ikoula.com"

--- a/examples/giantswarm-cluster/cluster_guppy_custom-node-names.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_custom-node-names.yaml
@@ -8,8 +8,8 @@ data:
     baseDomain: test.gigantic.io
     clusterDescription: test cluster configured with custom node names.
     kubernetesVersion: v1.22.9+vmware.1
-    organization: multi-project
     metadata:
+      organization: multi-project
       servicePriority: highest
 
     cloudDirector:
@@ -62,7 +62,8 @@ data:
   values: |
     clusterName: test-customname
     managementCluster: guppy
-    organization: multi-project
+    metadata:
+      organization: multi-project
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App

--- a/examples/giantswarm-cluster/cluster_guppy_multi-nic.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_multi-nic.yaml
@@ -8,8 +8,8 @@ data:
     baseDomain: test.gigantic.io
     clusterDescription: test cluster with 2 nics and static route.
     kubernetesVersion: v1.22.9+vmware.1
-    organization: multi-project
     metadata:
+      organization: multi-project
       servicePriority: highest
 
     cloudDirector:
@@ -65,7 +65,8 @@ data:
   values: |
     clusterName: test-multinic
     managementCluster: guppy
-    organization: multi-project
+    metadata:
+      organization: multi-project
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App

--- a/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
@@ -8,8 +8,8 @@ data:
     baseDomain: test.gigantic.io
     clusterDescription: test cluster configured with http proxy.
     kubernetesVersion: v1.22.9+vmware.1
-    organization: multi-project
     metadata:
+      organization: multi-project
       servicePriority: highest
 
     cloudDirector:
@@ -64,7 +64,8 @@ data:
   values: |
     clusterName: test-proxy
     managementCluster: guppy
-    organization: multi-project
+    metadata:
+      organization: multi-project
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App

--- a/helm/cluster-cloud-director/ci/ci-values.yaml
+++ b/helm/cluster-cloud-director/ci/ci-values.yaml
@@ -1,7 +1,8 @@
 baseDomain: k8s.test
 clusterDescription: "test cluster Xavier"
 kubernetesVersion: "v1.22.5+vmware.1"
-organization: "giantswarm"
+metadata:
+  organization: "giantswarm"
 
 cloudDirector:
   site: "https://vmware.ikoula.com"

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -28,7 +28,9 @@ app: {{ include "name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
-giantswarm.io/organization: {{ .Values.organization | quote }}
+{{- if .Values.metadata.organization }}
+giantswarm.io/organization: {{ .Values.metadata.organization | quote }}
+{{- end }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- end -}}
 

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -665,6 +665,10 @@
             "type": "object",
             "title": "Metadata",
             "properties": {
+                "organization": {
+                    "type": "string",
+                    "title": "Organization"
+                },
                 "servicePriority": {
                     "type": "string",
                     "title": "Service priority",
@@ -732,11 +736,6 @@
                 }
             },
             "default": {}
-        },
-        "organization": {
-            "type": "string",
-            "title": "Organization",
-            "default": ""
         },
         "osUsers": {
             "type": "array",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -105,7 +105,6 @@
         "connectivity",
         "nodeClasses",
         "nodePools",
-        "organization",
         "userContext"
     ],
     "properties": {

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -72,7 +72,6 @@ metadata:
   servicePriority: highest
 nodeClasses: {}
 nodePools: {}
-organization: ""
 osUsers:
   - name: giantswarm
     sudo: ALL=(ALL) NOPASSWD:ALL


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR moves the .organization property to .metadata.organization

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
