### PR TITLE
Remove `.includeClusterResourceSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ To migrate values from cluster-cloud-director 0.11.x, we provide below [yq](http
 yq eval --inplace '
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
+  del(.includeClusterResourceSet) |
   del(.oidc) |
   del(.servicePriority)
 ' ./values.yaml
@@ -33,6 +34,7 @@ yq eval --inplace '
 - :boom: Breaking schema changes:
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
+  - Removed `.includeClusterResourceSet`
 
 ### Fixed
 

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -630,10 +630,6 @@
                 }
             }
         },
-        "includeClusterResourceSet": {
-            "type": "string",
-            "title": "Include ClusterResourceSet"
-        },
         "kubectlImage": {
             "type": "object",
             "title": "Kubectl image",


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

Removes /includeClusterResourceSet, which is ineffectve. The implementation in cluster-shared is done in a way that it's not possible to overwrite the value. Also once effective, the setting should placed in one of the standard objects of the schema.

We removed it for the same reasons from Azure https://github.com/giantswarm/cluster-azure/pull/61 and AWS https://github.com/giantswarm/cluster-aws/pull/248

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
