### PR TITLE
Move `.rdeId` to `.internal.rdeId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ yq eval --inplace '
   with(select(.cloudDirector != null); .providerSpecific = .cloudDirector) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.organization != null); .metadata.organization = .organization) |
+  with(select(.rdeId != null); .internal.rdeId = .rdeId) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
   del(.clusterLabels) |
   del(.clusterDescription) |
@@ -26,6 +27,7 @@ yq eval --inplace '
   del(.includeClusterResourceSet) |
   del(.oidc) |
   del(.organization) |
+  del(.rdeId) |
   del(.servicePriority)
 ' ./values.yaml
 ```
@@ -46,6 +48,7 @@ yq eval --inplace '
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
   - `.organization` moved to `.metadata.organization`
+  - `.rdeId` moved to `.internal.rdeId`
   - Removed `.includeClusterResourceSet`
 
 ### Fixed

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -26,8 +26,8 @@ spec:
   {{- end }}
 
   # Not tested - not sure how
-  {{- with .internal.rdeId }}
-  rdeId: {{ . | quote }}
+  {{- if and .internal .internal.rdeId }}
+  rdeId: {{ .internal.rdeId | quote }}
   {{- end }}
   {{- with .Values.cluster }}
   parentUid: {{ .parentUid }}

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -26,8 +26,10 @@ spec:
   {{- end }}
 
   # Not tested - not sure how
+  {{- with .internal.rdeId }}
+  rdeId: {{ . | quote }}
+  {{- end }}
   {{- with .Values.cluster }}
-  rdeId: {{ .rdeId }}
   parentUid: {{ .parentUid }}
   useAsManagementCluster: {{ .useAsManagementCluster }}
   skipRDE: {{ .skipRDE }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -182,12 +182,6 @@
                     "description": "If set, create the cluster from a specific management cluster associated with this UID.",
                     "default": ""
                 },
-                "rdeId": {
-                    "type": "string",
-                    "title": "RDE ID",
-                    "description": "This cluster's entity ID in the VCD API.",
-                    "default": ""
-                },
                 "useAsManagementCluster": {
                     "type": "boolean",
                     "title": "Display as management cluster",
@@ -583,6 +577,16 @@
                         "ExpandPersistentVolumes=true,TTLAfterFinished=true"
                     ],
                     "default": "ExpandPersistentVolumes=true,TTLAfterFinished=true"
+                }
+            }
+        },
+        "internal": {
+            "type": "object",
+            "properties": {
+                "rdeId": {
+                    "type": "string",
+                    "title": "Runtime defined entity (RDE) identifier",
+                    "description": "This cluster's RDE ID in the VCD API."
                 }
             }
         },

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -11,7 +11,6 @@ cloudProvider:
     enabled: false
 cluster:
   parentUid: ""
-  rdeId: ""
   useAsManagementCluster: false
 clusterLabels: {}
 connectivity:
@@ -57,6 +56,7 @@ controlPlane:
   template: ""
 controllerManager:
   featureGates: ExpandPersistentVolumes=true,TTLAfterFinished=true
+internal: {}
 kubectlImage:
   name: giantswarm/kubectl
   registry: quay.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR

- moves `.rdeId` to `.internal.rdeId`
- Removes the empty default from the property

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
