### PR TITLE
Move `.cloudProvider` to `.providerSpecific.cloudProviderInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ To migrate values from cluster-cloud-director 0.11.x, we provide below [yq](http
 
 ```bash
 yq eval --inplace '
+  with(select(.cloudProvider != null); .providerSpecific.cloudProviderInterface = .cloudProvider) |
   with(select(.clusterLabels != null); .metadata.labels = .clusterLabels) |
   with(select(.clusterDescription != null); .metadata.description = .clusterDescription) |
   with(select(.cloudDirector != null); .providerSpecific = .cloudDirector) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.organization != null); .metadata.organization = .organization) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
+  del(.cloudProvider) |
   del(.clusterLabels) |
   del(.clusterDescription) |
   del(.cloudDirector) |
@@ -46,6 +48,7 @@ yq eval --inplace '
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
   - `.organization` moved to `.metadata.organization`
+  - `.cloudProvider` moved to `.providerSpecific.cloudProviderInterface`
   - Removed `.includeClusterResourceSet`
 
 ### Fixed

--- a/examples/giantswarm-cluster/cluster_guppy_custom-node-names.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_custom-node-names.yaml
@@ -18,11 +18,11 @@ data:
       site: https://vmware.ikoula.com
       ovdcNetwork: capvcd-192.168.52.0
 
-    ##### Not needed in VCD 10.4+
-    cloudProvider:
-      enableVirtualServiceSharedIP: false
-      oneArm:
-        enabled: true
+      ##### Not needed in VCD 10.4+
+      cloudProviderInterface:
+        enableVirtualServiceSharedIP: false
+        oneArm:
+          enabled: true
 
     controlPlane:
       catalog: giantswarm

--- a/examples/giantswarm-cluster/cluster_guppy_multi-nic.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_multi-nic.yaml
@@ -18,11 +18,11 @@ data:
       site: https://vmware.ikoula.com
       ovdcNetwork: capvcd-192.168.52.0
 
-    ##### Not needed in VCD 10.4+
-    cloudProvider:
-      enableVirtualServiceSharedIP: false
-      oneArm:
-        enabled: true
+      ##### Not needed in VCD 10.4+
+      cloudProviderInterface:
+        enableVirtualServiceSharedIP: false
+        oneArm:
+          enabled: true
 
     controlPlane:
       catalog: giantswarm

--- a/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
@@ -18,11 +18,11 @@ data:
       site: https://vmware.ikoula.com
       ovdcNetwork: network-test-2
 
-    ##### Not needed in VCD 10.4+
-    cloudProvider:
-      enableVirtualServiceSharedIP: false
-      oneArm:
-        enabled: true
+      ##### Not needed in VCD 10.4+
+      cloudProviderInterface:
+        enableVirtualServiceSharedIP: false
+        oneArm:
+          enabled: true
 
     proxy:
       enabled: true

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -52,6 +52,6 @@ spec:
         site: {{ .Values.providerSpecific.site | quote }}
         vAppName: {{ include "resource.default.name" $  | quote }}
         vipSubnet: {{ .Values.connectivity.network.loadBalancers.vipSubnet }}
-        enableVirtualServiceSharedIP: {{ .Values.cloudProvider.enableVirtualServiceSharedIP }}
+        enableVirtualServiceSharedIP: {{ .Values.providerSpecific.cloudProviderInterface.enableVirtualServiceSharedIP }}
         oneArm:
-          enabled: {{ .Values.cloudProvider.oneArm.enabled }}
+          enabled: {{ .Values.providerSpecific.cloudProviderInterface.oneArm.enabled }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -144,34 +144,6 @@
             "title": "Base DNS domain",
             "default": "k8s.test"
         },
-        "cloudProvider": {
-            "type": "object",
-            "title": "Cloud provider interface (CPI)",
-            "required": [
-                "enableVirtualServiceSharedIP",
-                "oneArm"
-            ],
-            "properties": {
-                "enableVirtualServiceSharedIP": {
-                    "type": "boolean",
-                    "title": "Enable sharing of IPs in virtual services",
-                    "description": "If enabled, multiple virtual services can share the same virtual IP address.",
-                    "default": true
-                },
-                "oneArm": {
-                    "type": "object",
-                    "title": "One-arm",
-                    "description": "If enabled, use an internal IP for the virtual service with a NAT rule to expose the external IP. Otherwise the virtual service will be exposed directly with the external IP.",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "title": "Enable",
-                            "default": false
-                        }
-                    }
-                }
-            }
-        },
         "cluster": {
             "type": "object",
             "title": "Cluster",
@@ -743,6 +715,34 @@
                 "site"
             ],
             "properties": {
+                "cloudProviderInterface": {
+                    "type": "object",
+                    "title": "Cloud provider interface (CPI)",
+                    "required": [
+                        "enableVirtualServiceSharedIP",
+                        "oneArm"
+                    ],
+                    "properties": {
+                        "enableVirtualServiceSharedIP": {
+                            "type": "boolean",
+                            "title": "Share IPs in virtual services",
+                            "description": "If enabled, multiple virtual services can share the same virtual IP address.",
+                            "default": true
+                        },
+                        "oneArm": {
+                            "type": "object",
+                            "title": "One-arm",
+                            "description": "If enabled, use an internal IP for the virtual service with a NAT rule to expose the external IP. Otherwise the virtual service will be exposed directly with the external IP.",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
                 "org": {
                     "type": "string",
                     "title": "Organization",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -5,10 +5,6 @@ apiServer:
   enableAdmissionPlugins: NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,DefaultStorageClass,Priority,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
   featureGates: TTLAfterFinished=true
 baseDomain: k8s.test
-cloudProvider:
-  enableVirtualServiceSharedIP: true
-  oneArm:
-    enabled: false
 cluster:
   parentUid: ""
   rdeId: ""
@@ -69,7 +65,11 @@ nodePools: {}
 osUsers:
   - name: giantswarm
     sudo: ALL=(ALL) NOPASSWD:ALL
-providerSpecific: {}
+providerSpecific:
+  cloudProviderInterface:
+    enableVirtualServiceSharedIP: true
+    oneArm:
+      enabled: false
 proxy:
   enabled: false
   secretName: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR

- moves `.cloudProvider` to `.providerSpecific.cloudProviderInterface`
- sets the properties in it not to be required, as we have default values for them

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
