### PR TITLE
Move `.connectivity.network.ntp` up by one level to `.connectivity.ntp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ yq eval --inplace '
   with(select(.clusterLabels != null); .metadata.labels = .clusterLabels) |
   with(select(.clusterDescription != null); .metadata.description = .clusterDescription) |
   with(select(.cloudDirector != null); .providerSpecific = .cloudDirector) |
+  with(select(.connectivity.network.ntp != null); .connectivity.ntp = .connectivity.network.ntp) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.organization != null); .metadata.organization = .organization) |
   with(select(.rdeId != null); .internal.rdeId = .rdeId) |
@@ -29,6 +30,7 @@ yq eval --inplace '
   del(.clusterLabels) |
   del(.clusterDescription) |
   del(.cloudDirector) |
+  del(.connectivity.network.ntp) |
   del(.includeClusterResourceSet) |
   del(.oidc) |
   del(.organization) |
@@ -57,6 +59,7 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates`
   - `.clusterLabels` moved to `.metadata.labels`
   - `.clusterDescription` moved to `.metadata.description`
   - `.cloudDirector` moved to `.providerSpecific`
+  - `.connectivity.network.ntp` moved to `.connectivity.ntp`
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
   - `.organization` moved to `.metadata.organization`

--- a/helm/cluster-cloud-director/templates/_ntp.tpl
+++ b/helm/cluster-cloud-director/templates/_ntp.tpl
@@ -3,15 +3,15 @@
 
 
 {{- define "ntpFiles" -}}
-{{- if or $.Values.connectivity.network.ntp.pools $.Values.connectivity.network.ntp.servers -}}
+{{- if or $.Values.connectivity.ntp.pools $.Values.connectivity.ntp.servers -}}
 - path: /etc/chrony/chrony.conf
   permissions: "0644"
   content: |
-    {{- range $.Values.connectivity.network.ntp.pools}}
+    {{- range $.Values.connectivity.ntp.pools }}
     pool {{.}} iburst
     {{- end }}
 
-    {{- range $.Values.connectivity.network.ntp.servers}}
+    {{- range $.Values.connectivity.ntp.servers }}
     server {{.}} iburst
     {{- end }}
 
@@ -30,7 +30,7 @@
 {{- end }}
 
 {{- define "ntpPostKubeadmCommands" -}}
-{{- if or $.Values.connectivity.network.ntp.pools $.Values.connectivity.network.ntp.servers }}
+{{- if or $.Values.connectivity.ntp.pools $.Values.connectivity.ntp.servers }}
 - systemctl daemon-reload
 - systemctl restart chrony
 {{- end -}}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -225,34 +225,6 @@
                                 }
                             }
                         },
-                        "ntp": {
-                            "type": "object",
-                            "title": "Time synchronization (NTP)",
-                            "description": "Servers/pools to synchronize this cluster's clocks with.",
-                            "properties": {
-                                "pools": {
-                                    "type": "array",
-                                    "title": "Pools",
-                                    "items": {
-                                        "type": "string",
-                                        "title": "Pool",
-                                        "examples": [
-                                            "ntp.ubuntu.com"
-                                        ]
-                                    },
-                                    "default": []
-                                },
-                                "servers": {
-                                    "type": "array",
-                                    "title": "Servers",
-                                    "items": {
-                                        "type": "string",
-                                        "title": "Server"
-                                    },
-                                    "default": []
-                                }
-                            }
-                        },
                         "pods": {
                             "type": "object",
                             "title": "Pods",
@@ -311,6 +283,32 @@
                                 }
                             },
                             "default": []
+                        }
+                    }
+                },
+                "ntp": {
+                    "type": "object",
+                    "title": "Time synchronization (NTP)",
+                    "description": "Servers/pools to synchronize this cluster's clocks with.",
+                    "properties": {
+                        "pools": {
+                            "type": "array",
+                            "title": "Pools",
+                            "items": {
+                                "type": "string",
+                                "title": "Pool",
+                                "examples": [
+                                    "ntp.ubuntu.com"
+                                ]
+                            }
+                        },
+                        "servers": {
+                            "type": "array",
+                            "title": "Servers",
+                            "items": {
+                                "type": "string",
+                                "title": "Server"
+                            }
                         }
                     }
                 }

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -9,9 +9,6 @@ connectivity:
     extraOvdcNetworks: []
     loadBalancers:
       vipSubnet: ""
-    ntp:
-      pools: []
-      servers: []
     pods:
       cidrBlocks:
         - 10.244.0.0/16
@@ -19,6 +16,7 @@ connectivity:
       cidrBlocks:
         - 172.31.0.0/16
     staticRoutes: []
+  ntp: {}
 controlPlane:
   catalog: ""
   customNodeLabels: []


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR

- moves `.connectivity.network.ntp` up by one level to `.connectivity.ntp`
- removes the empty default values for servers and pools

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
