### PR TITLE
Move `.cluster.skipRDE` to `.internal.skipRde`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ To migrate values from cluster-cloud-director 0.11.x, we provide below [yq](http
 yq eval --inplace '
   with(select(.cloudProvider != null); .providerSpecific.cloudProviderInterface = .cloudProvider) |
   with(select(.cluster.parentUid != null); .internal.parentUid = .cluster.parentUid) |
+  with(select(.cluster.skipRDE != null); .internal.skipRde = .cluster.skipRDE) |
   with(select(.cluster.useAsManagementCluster != null); .internal.useAsManagementCluster = .cluster.useAsManagementCluster) |
   with(select(.clusterLabels != null); .metadata.labels = .clusterLabels) |
   with(select(.clusterDescription != null); .metadata.description = .clusterDescription) |
@@ -23,6 +24,7 @@ yq eval --inplace '
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.organization != null); .metadata.organization = .organization) |
   with(select(.rdeId != null); .internal.rdeId = .rdeId) |
+  with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
   del(.cloudProvider) |
   del(.cluster) |
@@ -53,6 +55,7 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates`
   - Former `.apiServer.enableAdmissionPlugins`, now `.internal.apiServer.enableAdmissionPlugins`,  changed to array of strings
   - Former `.apiServer.featureGates`, now `.internal.apiServer.featureGates`, changed to array of objects
   - `.cluster.parentUid` moved to `.internal.parentUid`
+  - `.cluster.skipRDE` moved to `.internal.skipRde`
   - `.cluster.useAsManagementCluster` moved to `.internal.useAsManagementCluster`
   - `.clusterLabels` moved to `.metadata.labels`
   - `.clusterDescription` moved to `.metadata.description`

--- a/helm/cluster-cloud-director/templates/vcdcluster.yaml
+++ b/helm/cluster-cloud-director/templates/vcdcluster.yaml
@@ -35,8 +35,8 @@ spec:
   {{- if .Values.internal.useAsManagementCluster }}
   useAsManagementCluster: {{ .Values.internal.useAsManagementCluster }}
   {{- end }}
-  {{- if and .Values.cluster .Values.cluster.skipRDE }}
-  skipRDE: {{ .Values.cluster.skipRDE }}
+  {{- if .Values.internal.skipRde }}
+  skipRDE: {{ .Values.internal.skipRde }}
   {{- end }}
 
   # Authentication  

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -584,6 +584,11 @@
                     "title": "Runtime defined entity (RDE) identifier",
                     "description": "This cluster's RDE ID in the VCD API."
                 },
+                "skipRde": {
+                    "type": "boolean",
+                    "title": "Skip RDE",
+                    "description": "Set to true if the API schema extension is installed in the correct version in VCD to create CAPVCD entities in the API. Set to false otherwise."
+                },
                 "useAsManagementCluster": {
                     "type": "boolean",
                     "title": "Display as management cluster",


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR moves `.cluster.skipRDE` to `.internal.skipRde`. Note that the spelling is adapted to camelCase.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
