### PR TITLE
Move `.proxy` to `.connectivity.proxy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ yq eval --inplace '
   with(select(.connectivity.network.ntp != null); .connectivity.ntp = .connectivity.network.ntp) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.organization != null); .metadata.organization = .organization) |
+  with(select(.proxy != null); .connectivity.proxy = .proxy) |
   with(select(.rdeId != null); .internal.rdeId = .rdeId) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
   del(.cloudProvider) |
@@ -34,6 +35,7 @@ yq eval --inplace '
   del(.includeClusterResourceSet) |
   del(.oidc) |
   del(.organization) |
+  del(.proxy) |
   del(.rdeId) |
   del(.servicePriority)
 ' ./values.yaml
@@ -63,6 +65,7 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates`
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
   - `.organization` moved to `.metadata.organization`
+  - `.proxy` moved to `.connectivity.proxy`
   - `.cloudProvider` moved to `.providerSpecific.cloudProviderInterface`
   - `.rdeId` moved to `.internal.rdeId`
   - Removed `.includeClusterResourceSet`

--- a/README.md
+++ b/README.md
@@ -64,14 +64,12 @@ controlPlane:
   template: "ubuntu-2004-kube-v1.22.5"
   sizingPolicy: "m1.large"
 
-network:
-  loadBalancer:
-    vipSubnet: "178.170.32.1/24"
-
-proxy:
-    httpProxy: "http://user:pwd@192.168.52.220:3128"
-    httpsProxy: "http://user:pwd@192.168.52.220:3128"
-    noProxy: "100.64.0.0/13,100.96.0.0/11,192.168.52.0/24,178.170.32.0/24"
+connectivity:
+  network:
+    loadBalancer:
+      vipSubnet: "178.170.32.1/24"
+  proxy:
+    enabled: true
 
 nodeClasses:
   default:

--- a/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
@@ -24,10 +24,6 @@ data:
         oneArm:
           enabled: true
 
-    proxy:
-      enabled: true
-      secretName: ""
-
     controlPlane:
       catalog: giantswarm
       replicas: 3
@@ -38,6 +34,8 @@ data:
       network:
         loadBalancers:
           vipSubnet: "178.170.32.1/24"
+      proxy:
+        enabled: true
 
     nodeClasses:
       default:

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -67,7 +67,7 @@ use the cluster-apps-operator created secret <clusterName>-cluster-values as def
 */}}
 {{- define "containerdProxySecret" -}}
 {{- $defaultContainerdProxySecret := printf "%s-systemd-proxy" (include "resource.default.name" . ) -}}
-{{ .Values.proxy.secretName | default $defaultContainerdProxySecret }}
+{{ .Values.connectivity.proxy.secretName | default $defaultContainerdProxySecret }}
 {{- end -}}
 
 {{- define "containerdProxyConfig" -}}
@@ -119,7 +119,7 @@ files:
 {{- include "ntpFiles" . | nindent 2}}
 {{- include "sshFiles" . | nindent 2}}
 {{- include "registryFiles" . | nindent 2 }}
-{{- if $.Values.proxy.enabled }}
+{{- if $.Values.connectivity.proxy.enabled }}
 {{- include "containerdProxyConfig" . | nindent 2}}
 {{- end }}
 {{- if $.Values.connectivity.network.staticRoutes }}
@@ -128,7 +128,7 @@ files:
 
 preKubeadmCommands:
 - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
-{{- if $.Values.proxy.enabled }}
+{{- if $.Values.connectivity.proxy.enabled }}
 - systemctl daemon-reload
 - systemctl restart containerd
 {{- end }}

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -123,7 +123,7 @@ spec:
       {{- include "auditLogFiles" . | nindent 6 }}
       {{- include "sshFiles" . | nindent 6 }}
       {{- include "ntpFiles" . | nindent 6 }}
-      {{- if $.Values.proxy.enabled }}
+      {{- if $.Values.connectivity.proxy.enabled }}
       {{- include "containerdProxyConfig" . | nindent 6 }}
       {{- end }}
       {{- include "kubeadmFiles" . | nindent 6 }}
@@ -146,7 +146,7 @@ spec:
       - bash /tmp/kubeadm/patches/kube-apiserver-patch.sh {{ .Values.controlPlane.resourceRatio }}
       - bash /run/kubeadm/gs-update-kubeadm-yaml-skip-phases.sh
       - /bin/test ! -d /var/lib/kubelet && (/bin/mkdir -p /var/lib/kubelet && /bin/chmod 0750 /var/lib/kubelet)
-      {{- if $.Values.proxy.enabled }}
+      {{- if $.Values.connectivity.proxy.enabled }}
       - systemctl daemon-reload
       - systemctl restart containerd
       {{- end }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -311,6 +311,23 @@
                             }
                         }
                     }
+                },
+                "proxy": {
+                    "type": "object",
+                    "title": "Proxy",
+                    "description": "Whether/how outgoing traffic is routed through proxy servers.",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "title": "Enable"
+                        },
+                        "secretName": {
+                            "type": "string",
+                            "title": "Secret name",
+                            "description": "Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables.",
+                            "pattern": "^[a-z0-9-]{1,63}$"
+                        }
+                    }
                 }
             }
         },
@@ -793,24 +810,6 @@
                     "type": "string",
                     "title": "Endpoint",
                     "description": "VCD endpoint URL in the format https://VCD_HOST, without trailing slash."
-                }
-            }
-        },
-        "proxy": {
-            "type": "object",
-            "title": "Proxy",
-            "description": "Whether/how outgoing traffic is routed through proxy servers.",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "title": "Enable",
-                    "default": false
-                },
-                "secretName": {
-                    "type": "string",
-                    "title": "Secret name",
-                    "description": "Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables.",
-                    "default": ""
                 }
             }
         },

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -17,6 +17,7 @@ connectivity:
         - 172.31.0.0/16
     staticRoutes: []
   ntp: {}
+  proxy: {}
 controlPlane:
   catalog: ""
   customNodeLabels: []
@@ -77,9 +78,6 @@ providerSpecific:
     enableVirtualServiceSharedIP: true
     oneArm:
       enabled: false
-proxy:
-  enabled: false
-  secretName: ""
 sshTrustedUserCAKeys:
   - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 userContext:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

- Moves the .proxy object into .connectivity
- Removes empty default values
- Fixes the example in README

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
