### PR TITLE
Move `.kubernetesVersion` to `.internal.kubernetesVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ yq eval --inplace '
   with(select(.clusterDescription != null); .metadata.description = .clusterDescription) |
   with(select(.cloudDirector != null); .providerSpecific = .cloudDirector) |
   with(select(.connectivity.network.ntp != null); .connectivity.ntp = .connectivity.network.ntp) |
+  with(select(.kubernetesVersion != null); .internal.kubernetesVersion = .kubernetesVersion) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.organization != null); .metadata.organization = .organization) |
   with(select(.rdeId != null); .internal.rdeId = .rdeId) |
@@ -32,6 +33,7 @@ yq eval --inplace '
   del(.cloudDirector) |
   del(.connectivity.network.ntp) |
   del(.includeClusterResourceSet) |
+  del(.kubernetesVersion) |
   del(.oidc) |
   del(.organization) |
   del(.rdeId) |
@@ -60,6 +62,7 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates`
   - `.clusterDescription` moved to `.metadata.description`
   - `.cloudDirector` moved to `.providerSpecific`
   - `.connectivity.network.ntp` moved to `.connectivity.ntp`
+  - `.kubernetesVersion` moved to `.internal.kubernetesVersion`
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
   - `.organization` moved to `.metadata.organization`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Example of a values.yaml file for Cloud provider Ikoula with minimum input (maki
 
 ```yaml
 baseDomain: "cluster.local"
-kubernetesVersion: "v1.22.5+vmware.1"
 metadata:
   description: "glados test cluster"
   organization: "giantswarm"
@@ -94,6 +93,9 @@ userContext:
   secretRef:
     useSecretRef: true
     secretName: vcd-credentials
+
+internal:
+  kubernetesVersion: "v1.22.5+vmware.1"
 ```
 
 ## Limitations

--- a/examples/giantswarm-cluster/cluster_guppy_custom-node-names.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_custom-node-names.yaml
@@ -6,7 +6,8 @@ metadata:
 data:
   values: |
     baseDomain: test.gigantic.io
-    kubernetesVersion: v1.22.9+vmware.1
+    internal:
+      kubernetesVersion: v1.22.9+vmware.1
     metadata:
       description: test cluster configured with custom node names.
       organization: multi-project

--- a/examples/giantswarm-cluster/cluster_guppy_multi-nic.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_multi-nic.yaml
@@ -6,7 +6,8 @@ metadata:
 data:
   values: |
     baseDomain: test.gigantic.io
-    kubernetesVersion: v1.22.9+vmware.1
+    internal:
+      kubernetesVersion: v1.22.9+vmware.1
     metadata:
       description: test cluster with 2 nics and static route.
       organization: multi-project

--- a/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
+++ b/examples/giantswarm-cluster/cluster_guppy_proxy.yaml
@@ -6,7 +6,8 @@ metadata:
 data:
   values: |
     baseDomain: test.gigantic.io
-    kubernetesVersion: v1.22.9+vmware.1
+    internal:
+      kubernetesVersion: v1.22.9+vmware.1
     metadata:
       description: test cluster configured with http proxy.
       organization: multi-project

--- a/helm/cluster-cloud-director/ci/ci-values.yaml
+++ b/helm/cluster-cloud-director/ci/ci-values.yaml
@@ -1,5 +1,6 @@
 baseDomain: k8s.test
-kubernetesVersion: "v1.22.5+vmware.1"
+internal:
+  kubernetesVersion: "v1.22.5+vmware.1"
 metadata:
   description: "test cluster Xavier"
   organization: "giantswarm"

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -166,4 +166,4 @@ spec:
       name: {{ include "resource.default.name" . }}-control-plane-{{ include "mtRevisionByControlPlane" $ }}
       namespace: {{ .Release.Namespace }}
   replicas: {{ .Values.controlPlane.replicas }}
-  version: {{ .Values.kubernetesVersion }}
+  version: {{ .Values.internal.kubernetesVersion }}

--- a/helm/cluster-cloud-director/templates/machinedeployment.yaml
+++ b/helm/cluster-cloud-director/templates/machinedeployment.yaml
@@ -30,5 +30,5 @@ spec:
         kind: VCDMachineTemplate
         name: {{ include "resource.default.name" $ }}-{{ $value.class }}-{{ include "mtRevisionByClass" (merge (dict "currentValues" $.Values) $value) }}
         namespace: {{ $.Release.Namespace }}
-      version: {{ $.Values.kubernetesVersion }}
+      version: {{ $.Values.internal.kubernetesVersion }}
 {{- end }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -572,6 +572,11 @@
                         }
                     }
                 },
+                "kubernetesVersion": {
+                    "type": "string",
+                    "title": "Kubernetes version",
+                    "default": ""
+                },
                 "parentUid": {
                     "type": "string",
                     "title": "Management cluster UID",
@@ -610,11 +615,6 @@
                     "default": "1.23.5"
                 }
             }
-        },
-        "kubernetesVersion": {
-            "type": "string",
-            "title": "Kubernetes version",
-            "default": ""
         },
         "metadata": {
             "type": "object",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -574,8 +574,7 @@
                 },
                 "kubernetesVersion": {
                     "type": "string",
-                    "title": "Kubernetes version",
-                    "default": ""
+                    "title": "Kubernetes version"
                 },
                 "parentUid": {
                     "type": "string",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -59,12 +59,12 @@ internal:
     featureGates:
       - enabled: true
         name: TTLAfterFinished
+  kubernetesVersion: ""
   useAsManagementCluster: false
 kubectlImage:
   name: giantswarm/kubectl
   registry: quay.io
   tag: 1.23.5
-kubernetesVersion: ""
 metadata:
   servicePriority: highest
 nodeClasses: {}

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -59,7 +59,6 @@ internal:
     featureGates:
       - enabled: true
         name: TTLAfterFinished
-  kubernetesVersion: ""
   useAsManagementCluster: false
 kubectlImage:
   name: giantswarm/kubectl


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

- Move `.kubernetesVersion` to `.internal.kubernetesVersion` (like in Azure and AWS)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
