### PR TITLE
Move `.osUsers` and `.sshTrustedUserCAKeys` to `.connectivity.shell`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ yq eval --inplace '
   with(select(.kubernetesVersion != null); .internal.kubernetesVersion = .kubernetesVersion) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.organization != null); .metadata.organization = .organization) |
+  with(select(.osUsers != null); .connectivity.osUsers = .osUsers) |
   with(select(.proxy != null); .connectivity.proxy = .proxy) |
   with(select(.rdeId != null); .internal.rdeId = .rdeId) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
@@ -71,6 +72,7 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates`
   - `.kubernetesVersion` moved to `.internal.kubernetesVersion`
   - `.servicePriority` moved to `.metadata.servicePriority`
   - `.oidc` moved to `.controlPlane.oidc`
+  - `.osUsers` moved to `.connectivity.osUsers`
   - `.organization` moved to `.metadata.organization`
   - `.proxy` moved to `.connectivity.proxy`
   - `.cloudProvider` moved to `.providerSpecific.cloudProviderInterface`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@ yq eval --inplace '
   with(select(.kubernetesVersion != null); .internal.kubernetesVersion = .kubernetesVersion) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
   with(select(.organization != null); .metadata.organization = .organization) |
-  with(select(.osUsers != null); .connectivity.osUsers = .osUsers) |
+  with(select(.osUsers != null); .connectivity.shell.osUsers = .osUsers) |
   with(select(.proxy != null); .connectivity.proxy = .proxy) |
   with(select(.rdeId != null); .internal.rdeId = .rdeId) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
+  with(select(.sshTrustedUserCAKeys != null); .connectivity.shell.sshTrustedUserCAKeys = .sshTrustedUserCAKeys) |
   del(.clusterName) |
   with(select(.servicePriority != null); .metadata.servicePriority = .servicePriority) |
   del(.cloudProvider) |
@@ -40,10 +41,12 @@ yq eval --inplace '
   del(.includeClusterResourceSet) |
   del(.kubernetesVersion) |
   del(.oidc) |
+  del(.osUsers) |
   del(.organization) |
   del(.proxy) |
   del(.rdeId) |
-  del(.servicePriority)
+  del(.servicePriority) |
+  del(.sshTrustedUserCAKeys)
 ' ./values.yaml
 ```
 
@@ -77,6 +80,7 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates`
   - `.proxy` moved to `.connectivity.proxy`
   - `.cloudProvider` moved to `.providerSpecific.cloudProviderInterface`
   - `.rdeId` moved to `.internal.rdeId`
+  - `.sshTrustedUserCAKeys` moved to `.connectivity.shell.sshTrustedUserCAKeys`
   - Removed `.includeClusterResourceSet`
 - Non-breaking schema changes and clean-ups
   - Remove unused `.clusterName` value

--- a/helm/cluster-cloud-director/templates/_ssh.tpl
+++ b/helm/cluster-cloud-director/templates/_ssh.tpl
@@ -1,5 +1,5 @@
 # The helper functions here can be called in templates and _helpers.tpl
-# This file should be self-sufficient. Don't call any functions from _helpers.tpl
+# This file should be self-sufficient. Don't call any functions from _helpers.tpl
 
 
 {{- define "sshFiles" -}}
@@ -22,8 +22,8 @@
 {{- end -}}
 
 {{- define "sshUsers" -}}
-{{- if $.Values.osUsers -}}
+{{- if $.Values.connectivity.shell.osUsers -}}
 users:
-  {{- $.Values.osUsers | toYaml | nindent 2}}
+  {{- $.Values.connectivity.shell.osUsers | toYaml | nindent 2 }}
 {{- end }}
 {{- end -}}

--- a/helm/cluster-cloud-director/templates/_ssh.tpl
+++ b/helm/cluster-cloud-director/templates/_ssh.tpl
@@ -3,11 +3,11 @@
 
 
 {{- define "sshFiles" -}}
-{{- if $.Values.sshTrustedUserCAKeys -}}
+{{- if $.Values.connectivity.shell.sshTrustedUserCAKeys -}}
 - path: /etc/ssh/trusted-user-ca-keys.pem
   permissions: "0600"
   content: |
-    {{- range $.Values.sshTrustedUserCAKeys}}
+    {{- range $.Values.connectivity.shell.sshTrustedUserCAKeys }}
     {{.}}
     {{- end }}
 - path: /etc/ssh/sshd_config

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -322,6 +322,44 @@
                             "pattern": "^[a-z0-9-]{1,63}$"
                         }
                     }
+                },
+                "shell": {
+                    "type": "object",
+                    "title": "Shell access",
+                    "properties": {
+                        "osUsers": {
+                            "type": "array",
+                            "title": "OS Users",
+                            "description": "Configuration for OS users in cluster nodes.",
+                            "items": {
+                                "type": "object",
+                                "title": "User",
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "Name",
+                                        "description": "Username of the user.",
+                                        "minLength": 2,
+                                        "pattern": "^[a-z][-a-z0-9]+$"
+                                    },
+                                    "sudo": {
+                                        "type": "string",
+                                        "title": "Sudoers configuration",
+                                        "description": "Permissions string to add to /etc/sudoers for this user."
+                                    }
+                                }
+                            },
+                            "default": [
+                                {
+                                    "name": "giantswarm",
+                                    "sudo": "ALL=(ALL) NOPASSWD:ALL"
+                                }
+                            ]
+                        }
+                    }
                 }
             }
         },
@@ -725,31 +763,6 @@
                 }
             },
             "default": {}
-        },
-        "osUsers": {
-            "type": "array",
-            "title": "OS Users",
-            "description": "Configuration for OS users in cluster nodes.",
-            "items": {
-                "type": "object",
-                "title": "User",
-                "required": [
-                    "name"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "description": "Username of the user."
-                    }
-                }
-            },
-            "default": [
-                {
-                    "name": "giantswarm",
-                    "sudo": "ALL=(ALL) NOPASSWD:ALL"
-                }
-            ]
         },
         "providerSpecific": {
             "type": "object",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -358,6 +358,17 @@
                                     "sudo": "ALL=(ALL) NOPASSWD:ALL"
                                 }
                             ]
+                        },
+                        "sshTrustedUserCAKeys": {
+                            "type": "array",
+                            "title": "Trusted SSH cert issuers",
+                            "description": "CA certificates of issuers that are trusted to sign SSH user certificates.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [
+                                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
+                            ]
                         }
                     }
                 }
@@ -823,17 +834,6 @@
                     "description": "VCD endpoint URL in the format https://VCD_HOST, without trailing slash."
                 }
             }
-        },
-        "sshTrustedUserCAKeys": {
-            "type": "array",
-            "title": "Trusted SSH cert issuers",
-            "description": "CA certificates of issuers that are trusted to sign SSH user certificates.",
-            "items": {
-                "type": "string"
-            },
-            "default": [
-                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"
-            ]
         },
         "userContext": {
             "type": "object",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -21,6 +21,8 @@ connectivity:
     osUsers:
       - name: giantswarm
         sudo: ALL=(ALL) NOPASSWD:ALL
+    sshTrustedUserCAKeys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 controlPlane:
   catalog: ""
   customNodeLabels: []
@@ -77,8 +79,6 @@ providerSpecific:
     enableVirtualServiceSharedIP: true
     oneArm:
       enabled: false
-sshTrustedUserCAKeys:
-  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 userContext:
   secretRef:
     secretName: ""

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -17,6 +17,10 @@ connectivity:
     staticRoutes: []
   ntp: {}
   proxy: {}
+  shell:
+    osUsers:
+      - name: giantswarm
+        sudo: ALL=(ALL) NOPASSWD:ALL
 controlPlane:
   catalog: ""
   customNodeLabels: []
@@ -68,9 +72,6 @@ metadata:
   servicePriority: highest
 nodeClasses: {}
 nodePools: {}
-osUsers:
-  - name: giantswarm
-    sudo: ALL=(ALL) NOPASSWD:ALL
 providerSpecific:
   cloudProviderInterface:
     enableVirtualServiceSharedIP: true


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR

- Moves `.osUsers` and `.sshTrustedUserCAKeys` to the common `.connectivity.shell` object.
- Also applies a straightforward validation pattern to user name strings. Used [this document](https://systemd.io/USER_NAMES/) as a reference.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
