### PR TITLE
Move `.controllerManager` to `.internal.controllerManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ yq eval --inplace '
   with(select(.clusterDescription != null); .metadata.description = .clusterDescription) |
   with(select(.cloudDirector != null); .providerSpecific = .cloudDirector) |
   with(select(.connectivity.network.ntp != null); .connectivity.ntp = .connectivity.network.ntp) |
+  with(select(.controllerManager != null); .internal.controllerManager = .controllerManager) |
   with(select(.kubernetesVersion != null); .internal.kubernetesVersion = .kubernetesVersion) |
   with(select(.nodeClasses != null); .providerSpecific.nodeClasses = .nodeClasses) |
   with(select(.oidc != null); .controlPlane.oidc = .oidc) |
@@ -39,6 +40,7 @@ yq eval --inplace '
   del(.clusterDescription) |
   del(.cloudDirector) |
   del(.connectivity.network.ntp) |
+  del(.controllerManager) |
   del(.includeClusterResourceSet) |
   del(.kubernetesVersion) |
   del(.nodeClasses) |
@@ -52,7 +54,7 @@ yq eval --inplace '
 ' ./values.yaml
 ```
 
-TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates` is set.
+TODO: Warn when `.apiServer.enableAdmissionPlugins`, `.apiServer.featureGates`, or `.controllerManager.featureGates` is set.
 
 </details>
 
@@ -67,6 +69,7 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates`
   - `.apiServer.certSANs` moved to `.controlPlane.certSANs`
   - Former `.apiServer.enableAdmissionPlugins`, now `.internal.apiServer.enableAdmissionPlugins`,  changed to array of strings
   - Former `.apiServer.featureGates`, now `.internal.apiServer.featureGates`, changed to array of objects
+  - Former `.controllerManager.featureGates`, now `.internal.controllerManager.featureGates`, changed to array of objects
   - `.cluster.parentUid` moved to `.internal.parentUid`
   - `.cluster.skipRDE` moved to `.internal.skipRde`
   - `.cluster.useAsManagementCluster` moved to `.internal.useAsManagementCluster`
@@ -74,6 +77,7 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins` or `.apiServer.featureGates`
   - `.clusterDescription` moved to `.metadata.description`
   - `.cloudDirector` moved to `.providerSpecific`
   - `.connectivity.network.ntp` moved to `.connectivity.ntp`
+  - `.controllerManager` moved to `.internal.controllerManager`
   - `.kubernetesVersion` moved to `.internal.kubernetesVersion`
   - `.nodeClasses` moved to `.providerSpecific.nodeClasses`
   - `.servicePriority` moved to `.metadata.servicePriority`

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -74,7 +74,11 @@ spec:
           bind-address: "0.0.0.0"
           cloud-provider: external
           enable-hostpath-provisioner: "true"          
-          feature-gates: {{ .Values.controllerManager.featureGates }}
+          {{- if .Values.internal.controllerManager.featureGates }}
+          feature-gates: {{ range $index, $element := .Values.internal.controllerManager.featureGates -}}
+            {{ if $index }},{{ end }}{{ $element.name }}={{ $element.enabled }}
+          {{- end }}
+          {{- end }}
           logtostderr: "true"
           profiling: "false"
       dns:

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -29,6 +29,24 @@
             ],
             "exclusiveMinimum": 0
         },
+        "featureGate": {
+            "type": "object",
+            "title": "Feature gate",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                },
+                "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "examples": [
+                        "UserNamespacesStatelessPodsSupport"
+                    ],
+                    "pattern": "^[A-Za-z0-9]+$"
+                }
+            }
+        },
         "nodeLabels": {
             "type": "array",
             "title": "Node labels",
@@ -103,7 +121,6 @@
     "type": "object",
     "required": [
         "baseDomain",
-        "controllerManager",
         "controlPlane",
         "connectivity",
         "nodePools",
@@ -550,24 +567,6 @@
                 }
             }
         },
-        "controllerManager": {
-            "type": "object",
-            "title": "Controller manager",
-            "required": [
-                "featureGates"
-            ],
-            "properties": {
-                "featureGates": {
-                    "type": "string",
-                    "title": "Feature gates",
-                    "description": "Comma-separated list of feature gates.",
-                    "examples": [
-                        "ExpandPersistentVolumes=true,TTLAfterFinished=true"
-                    ],
-                    "default": "ExpandPersistentVolumes=true,TTLAfterFinished=true"
-                }
-            }
-        },
         "internal": {
             "type": "object",
             "properties": {
@@ -605,24 +604,33 @@
                             "title": "Feature gates",
                             "description": "API server feature gate activation/deactivation.",
                             "items": {
-                                "type": "object",
-                                "title": "Feature gate",
-                                "properties": {
-                                    "enabled": {
-                                        "type": "boolean",
-                                        "title": "Enabled"
-                                    },
-                                    "name": {
-                                        "type": "string",
-                                        "title": "Name",
-                                        "examples": [
-                                            "UserNamespacesStatelessPodsSupport"
-                                        ],
-                                        "pattern": "^[A-Za-z0-9]+$"
-                                    }
-                                }
+                                "$ref": "#/$defs/featureGate"
                             },
                             "default": [
+                                {
+                                    "enabled": true,
+                                    "name": "TTLAfterFinished"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "controllerManager": {
+                    "type": "object",
+                    "title": "Controller manager",
+                    "properties": {
+                        "featureGates": {
+                            "type": "array",
+                            "title": "Feature gates",
+                            "description": "Controller manager feature gate activation/deactivation.",
+                            "items": {
+                                "$ref": "#/$defs/featureGate"
+                            },
+                            "default": [
+                                {
+                                    "enabled": true,
+                                    "name": "ExpandPersistentVolumes"
+                                },
                                 {
                                     "enabled": true,
                                     "name": "TTLAfterFinished"

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -44,8 +44,6 @@ controlPlane:
     usernamePrefix: ""
   replicas: 0
   resourceRatio: 8
-controllerManager:
-  featureGates: ExpandPersistentVolumes=true,TTLAfterFinished=true
 internal:
   apiServer:
     enableAdmissionPlugins:
@@ -60,6 +58,12 @@ internal:
       - ServiceAccount
       - ValidatingAdmissionWebhook
     featureGates:
+      - enabled: true
+        name: TTLAfterFinished
+  controllerManager:
+    featureGates:
+      - enabled: true
+        name: ExpandPersistentVolumes
       - enabled: true
         name: TTLAfterFinished
   useAsManagementCluster: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

- Moves `.controllerManager` to `.internal.controllerManager`
- Makes `featureGate` a re-usable schema definition
- Harmonizes the controllerManager feature gates schema with the apiServer ones

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
