### PR TITLE
Remove empty default values from schema, add some property defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ TODO: Warn when `.apiServer.enableAdmissionPlugins`, `.apiServer.featureGates`, 
   - Removed `.includeClusterResourceSet`
 - Non-breaking schema changes and clean-ups
   - Remove unused `.clusterName` value
+  - Change the `.controlPlane.replicas` default to 1
+  - Add a default value of 1 to `.nodePools.*.replicas`
+  - Mark `.connectivity.containerRegistries` as optional (not required)
 
 ### Fixed
 

--- a/helm/cluster-cloud-director/ci/ci-values.yaml
+++ b/helm/cluster-cloud-director/ci/ci-values.yaml
@@ -26,6 +26,11 @@ controlPlane:
   catalog: "giantswarm"
   template: "ubuntu-2004-kube-v1.22.5"
   sizingPolicy: "m1.medium"
+  oidc:
+    clientId: fake-client-id
+    groupsClaim: groups
+    issuerUrl: https://idp.example.com/
+    usernameClaim: username
 
 connectivity:
   network:

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -186,8 +186,7 @@
                                 }
                             }
                         }
-                    },
-                    "default": {}
+                    }
                 },
                 "network": {
                     "type": "object",
@@ -205,15 +204,13 @@
                             "properties": {
                                 "host": {
                                     "type": "string",
-                                    "title": "Host",
-                                    "default": ""
+                                    "title": "Host"
                                 },
                                 "port": {
                                     "type": "integer",
                                     "title": "Port number"
                                 }
-                            },
-                            "default": {}
+                            }
                         },
                         "extraOvdcNetworks": {
                             "type": "array",
@@ -221,8 +218,7 @@
                             "description": "OVDC networks to attach VMs to, additionally.",
                             "items": {
                                 "type": "string"
-                            },
-                            "default": []
+                            }
                         },
                         "loadBalancers": {
                             "type": "object",
@@ -234,8 +230,7 @@
                                 "vipSubnet": {
                                     "type": "string",
                                     "title": "Virtual IP subnet",
-                                    "description": "Virtual IP CIDR for the external network.",
-                                    "default": ""
+                                    "description": "Virtual IP CIDR for the external network."
                                 }
                             }
                         },
@@ -295,8 +290,7 @@
                                         "format": "ipv4"
                                     }
                                 }
-                            },
-                            "default": []
+                            }
                         }
                     }
                 },
@@ -409,8 +403,7 @@
                 "catalog": {
                     "$ref": "#/$defs/catalog",
                     "title": "Catalog",
-                    "description": "VCD catalog where the VM template is stored.",
-                    "default": ""
+                    "description": "VCD catalog where the VM template is stored."
                 },
                 "certSANs": {
                     "type": "array",
@@ -423,8 +416,7 @@
                 },
                 "customNodeLabels": {
                     "$ref": "#/$defs/nodeLabels",
-                    "title": "Custom node labels",
-                    "default": []
+                    "title": "Custom node labels"
                 },
                 "diskSizeGB": {
                     "$ref": "#/$defs/diskSizeGB",
@@ -503,38 +495,32 @@
                         "caFile": {
                             "type": "string",
                             "title": "Certificate authority file",
-                            "description": "Path to identity provider's CA certificate in PEM format.",
-                            "default": ""
+                            "description": "Path to identity provider's CA certificate in PEM format."
                         },
                         "clientId": {
                             "type": "string",
                             "title": "Client ID",
-                            "description": "OIDC client identifier to identify with.",
-                            "default": ""
+                            "description": "OIDC client identifier to identify with."
                         },
                         "groupsClaim": {
                             "type": "string",
                             "title": "Groups claim",
-                            "description": "Name of the identity token claim bearing the user's group memberships.",
-                            "default": ""
+                            "description": "Name of the identity token claim bearing the user's group memberships."
                         },
                         "issuerUrl": {
                             "type": "string",
                             "title": "Issuer URL",
-                            "description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part.",
-                            "default": ""
+                            "description": "URL of the provider which allows the API server to discover public signing keys, not including any path. Discovery URL without the '/.well-known/openid-configuration' part."
                         },
                         "usernameClaim": {
                             "type": "string",
                             "title": "Username claim",
-                            "description": "Name of the identity token claim bearing the unique user identifier.",
-                            "default": ""
+                            "description": "Name of the identity token claim bearing the unique user identifier."
                         },
                         "usernamePrefix": {
                             "type": "string",
                             "title": "Username prefix",
-                            "description": "Prefix prepended to username values to prevent clashes with existing names.",
-                            "default": ""
+                            "description": "Prefix prepended to username values to prevent clashes with existing names."
                         }
                     }
                 },
@@ -745,8 +731,7 @@
                         "minimum": 1
                     }
                 }
-            },
-            "default": {}
+            }
         },
         "providerSpecific": {
             "type": "object",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -531,7 +531,7 @@
                     "type": "integer",
                     "title": "Number of nodes",
                     "description": "Number of control plane instances to create. Must be an odd number.",
-                    "default": 0
+                    "default": 1
                 },
                 "resourceRatio": {
                     "type": "integer",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -136,7 +136,6 @@
             "title": "Connectivity",
             "description": "Configurations related to cluster connectivity such as container registries.",
             "required": [
-                "containerRegistries",
                 "network"
             ],
             "properties": {

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -727,6 +727,8 @@
                     },
                     "replicas": {
                         "type": "integer",
+                        "title": "Number of nodes",
+                        "default": 1,
                         "minimum": 1
                     }
                 }

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -2,19 +2,15 @@
 
 baseDomain: k8s.test
 connectivity:
-  containerRegistries: {}
   network:
     controlPlaneEndpoint: {}
-    extraOvdcNetworks: []
-    loadBalancers:
-      vipSubnet: ""
+    loadBalancers: {}
     pods:
       cidrBlocks:
         - 10.244.0.0/16
     services:
       cidrBlocks:
         - 172.31.0.0/16
-    staticRoutes: []
   ntp: {}
   proxy: {}
   shell:
@@ -24,8 +20,6 @@ connectivity:
     sshTrustedUserCAKeys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 controlPlane:
-  catalog: ""
-  customNodeLabels: []
   diskSizeGB: 30
   dns:
     imageRepository: projects.registry.vmware.com/tkg
@@ -35,14 +29,8 @@ controlPlane:
     imageTag: 3.5.4-0-k8s
   image:
     repository: projects.registry.vmware.com/tkg
-  oidc:
-    caFile: ""
-    clientId: ""
-    groupsClaim: ""
-    issuerUrl: ""
-    usernameClaim: ""
-    usernamePrefix: ""
-  replicas: 0
+  oidc: {}
+  replicas: 1
   resourceRatio: 8
 internal:
   apiServer:
@@ -73,7 +61,6 @@ kubectlImage:
   tag: 1.23.5
 metadata:
   servicePriority: highest
-nodePools: {}
 providerSpecific:
   cloudProviderInterface:
     enableVirtualServiceSharedIP: true


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2132

This PR

- removes all empty default values
- changes the `.controlPlane.replicas` default value to 1 (as 0 is not a meaningful value)
- adds a default value of 1 to `.nodePools.*.replicas` (previously no default)
- adds title annotation to `.nodePools.*.replicas`
- sets `.connectivity.containerRegistries` to not required
- adds CI values for required properties in `.controlPlane.oidc` (since the empty default values got removed)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
