### PR TITLE
Add tolerations for hubble rely and ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Normalize values schema according to `schemalint` v2.
-- Update cilium to 0.10.0.
+- Update cilium to 0.10.0 (and add tolerations to hubble relay and UI).
 
 ### Fixed
 

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -36,6 +36,29 @@ spec:
     hubble:
       relay:
         enabled: true
+        tolerations:
+          - key: "node-role.kubernetes.io/master"
+            effect: "NoSchedule"
+            operator: "Exists"
+          - key: "node-role.kubernetes.io/control-plane"
+            effect: "NoSchedule"
+            operator: "Exists"
+          - key: "node.cloudprovider.kubernetes.io/uninitialized"
+            effect: "NoSchedule"
+            operator: "Equal"
+            value: "true"
+      ui:
+        tolerations:
+          - key: "node-role.kubernetes.io/master"
+            effect: "NoSchedule"
+            operator: "Exists"
+          - key: "node-role.kubernetes.io/control-plane"
+            effect: "NoSchedule"
+            operator: "Exists"
+          - key: "node.cloudprovider.kubernetes.io/uninitialized"
+            effect: "NoSchedule"
+            operator: "Equal"
+            value: "true"
     defaultPolicies:
       enabled: true
       tolerations:


### PR DESCRIPTION
Found while testing https://github.com/giantswarm/cluster-cloud-director/pull/146

Otherwise:

```
Warning  FailedScheduling  81s   default-scheduler  0/5 nodes are available: 2 node(s) had untolerated taint {node-role.kubernetes.io/master: }, 3 node(s) had untolerated taint {node.cloudprovider.kubernetes.io/uninitialized: true}. preemption: 0/5 nodes are available: 5 Preemption is not helpful for scheduling.
```

See more details in Slack: https://gigantic.slack.com/archives/C01F7T2MNRL/p1687373676074119