### PR TITLE
Set value for terminated pod gc threshold to be consistent with vintage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage ) 
+
 ## [0.12.2] - 2023-07-03
 
 ### Added

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -77,6 +77,7 @@ spec:
           bind-address: "0.0.0.0"
           cloud-provider: external
           enable-hostpath-provisioner: "true"          
+          terminated-pod-gc-threshold: "125"
           {{- if .Values.internal.controllerManager.featureGates }}
           feature-gates: {{ range $index, $element := .Values.internal.controllerManager.featureGates -}}
             {{ if $index }},{{ end }}{{ $element.name }}={{ $element.enabled }}


### PR DESCRIPTION
https://github.com/giantswarm/klingel/issues/91

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Set value for terminated pod gc threshold to be consistent with vintage

### Testing

Description on how {APP-NAME} can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for {APP-NAME} installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.
