### PR TITLE
Consolidate containerd config.toml in single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `.connectivity.proxy.secretName` defaulting to `<clusterName>-cluster-values`.
-- Consolidate containerd `config.toml` into single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
 
 ### Added
 
 - Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage ) 
+
+### Changed
+- Consolidate containerd `config.toml` into single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
 
 ## [0.12.2] - 2023-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `.connectivity.proxy.secretName` defaulting to `<clusterName>-cluster-values`.
+- Consolidate containerd `config.toml` into single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set value for `controller-manager` `terminated-pod-gc-threshold` to `125` ( consistent with vintage ) 
 
 ### Changed
-- Consolidate containerd `config.toml` into single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
+- Consolidate containerd `config.toml` into a single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
 
 ## [0.12.2] - 2023-07-03
 

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -69,7 +69,7 @@ Configurations related to cluster connectivity such as container registries.
 | `connectivity.ntp.servers[*]` | **Server**|**Type:** `string`<br/>|
 | `connectivity.proxy` | **Proxy** - Whether/how outgoing traffic is routed through proxy servers.|**Type:** `object`<br/>|
 | `connectivity.proxy.enabled` | **Enable**|**Type:** `boolean`<br/>|
-| `connectivity.proxy.secretName` | **Secret name** - Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables. If empty the value will be defaulted to <clusterName>-cluster-values.|**Type:** `string`<br/>**Value pattern:** `^[a-z0-9-]{0,63}$`<br/>|
+| `connectivity.proxy.secretName` | **Secret name** - Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables. If empty, the value will be defaulted to <clusterName>-cluster-values.|**Type:** `string`<br/>**Value pattern:** `^[a-z0-9-]{0,63}$`<br/>|
 | `connectivity.shell` | **Shell access**|**Type:** `object`<br/>|
 | `connectivity.shell.osUsers` | **OS Users** - Configuration for OS users in cluster nodes.|**Type:** `array`<br/>**Default:** `[{"name":"giantswarm","sudo":"ALL=(ALL) NOPASSWD:ALL"}]`|
 | `connectivity.shell.osUsers[*]` | **User**|**Type:** `object`<br/>|

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -22,6 +22,10 @@ Properties within the `.internal` top-level object
 | `internal.kubernetesVersion` | **Kubernetes version**|**Type:** `string`<br/>|
 | `internal.parentUid` | **Management cluster UID** - If set, create the cluster from a specific management cluster associated with this UID.|**Type:** `string`<br/>|
 | `internal.rdeId` | **Runtime defined entity (RDE) identifier** - This cluster's RDE ID in the VCD API.|**Type:** `string`<br/>|
+| `internal.sandboxContainerImage` | **Sandbox Container image**|**Type:** `object`<br/>|
+| `internal.sandboxContainerImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"tkg/pause"`|
+| `internal.sandboxContainerImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"projects.registry.vmware.com/"`|
+| `internal.sandboxContainerImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"3.7"`|
 | `internal.skipRde` | **Skip RDE** - Set to true if the API schema extension is installed in the correct version in VCD to create CAPVCD entities in the API. Set to false otherwise.|**Type:** `boolean`<br/>|
 | `internal.useAsManagementCluster` | **Display as management cluster**|**Type:** `boolean`<br/>**Default:** `false`|
 
@@ -31,7 +35,7 @@ Configurations related to cluster connectivity such as container registries.
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `connectivity.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>|
+| `connectivity.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{}`|
 | `connectivity.containerRegistries.*` |**None**|**Type:** `array`<br/>|
 | `connectivity.containerRegistries.*[*]` |**None**|**Type:** `object`<br/>|
 | `connectivity.containerRegistries.*[*].credentials` | **Credentials** - Credentials for the endpoint.|**Type:** `object`<br/>|
@@ -65,7 +69,7 @@ Configurations related to cluster connectivity such as container registries.
 | `connectivity.ntp.servers[*]` | **Server**|**Type:** `string`<br/>|
 | `connectivity.proxy` | **Proxy** - Whether/how outgoing traffic is routed through proxy servers.|**Type:** `object`<br/>|
 | `connectivity.proxy.enabled` | **Enable**|**Type:** `boolean`<br/>|
-| `connectivity.proxy.secretName` | **Secret name** - Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables.|**Type:** `string`<br/>**Value pattern:** `^[a-z0-9-]{1,63}$`<br/>|
+| `connectivity.proxy.secretName` | **Secret name** - Name of a secret resource used by containerd to obtain the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables. If empty the value will be defaulted to <clusterName>-cluster-values.|**Type:** `string`<br/>**Value pattern:** `^[a-z0-9-]{0,63}$`<br/>|
 | `connectivity.shell` | **Shell access**|**Type:** `object`<br/>|
 | `connectivity.shell.osUsers` | **OS Users** - Configuration for OS users in cluster nodes.|**Type:** `array`<br/>**Default:** `[{"name":"giantswarm","sudo":"ALL=(ALL) NOPASSWD:ALL"}]`|
 | `connectivity.shell.osUsers[*]` | **User**|**Type:** `object`<br/>|

--- a/helm/cluster-cloud-director/files/etc/containerd/config.toml
+++ b/helm/cluster-cloud-director/files/etc/containerd/config.toml
@@ -1,0 +1,50 @@
+version = 2
+
+# recommended defaults from https://github.com/containerd/containerd/blob/main/docs/ops.md#base-configuration
+# set containerd as a subreaper on linux when it is not running as PID 1
+subreaper = true
+# set containerd's OOM score
+oom_score = -999
+disabled_plugins = []
+[plugins."containerd.runtime.v1.linux"]
+# shim binary name/path
+shim = "containerd-shim"
+# runtime binary name/path
+runtime = "runc"
+# do not use a shim when starting containers, saves on memory but
+# live restore is not supported
+no_shim = false
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+# setting runc.options unsets parent settings
+runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
+[plugins."io.containerd.grpc.v1.cri"]
+sandbox_image = "{{ .Values.internal.sandboxContainerImage.registry }}/{{ .Values.internal.sandboxContainerImage.name }}:{{ .Values.internal.sandboxContainerImage.tag }}"
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+  {{- range $host, $config := .Values.connectivity.containerRegistries }}
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
+      endpoint = [
+        {{- range $value := $config -}}
+        "https://{{$value.endpoint}}",
+        {{- end -}}
+    ]
+  {{- end }}
+[plugins."io.containerd.grpc.v1.cri".registry.configs]
+  {{ range $host, $config := .Values.connectivity.containerRegistries -}}
+    {{ range $value := $config -}}
+      {{ with $value.credentials -}}
+      [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]
+      {{ if and .username .password -}}
+      auth = {{ printf "%s:%s" .username .password | b64enc | quote }}
+      {{- else if .auth -}}
+      auth = {{ .auth | quote }}
+      {{ else if .identitytoken -}}
+      identitytoken = {{ .identitytoken  | quote }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -231,7 +231,7 @@ mount containerd configuration.
   permissions: "0600"
   contentFrom:
     secret:
-      name: {{ include "registrySecretName" $ }}
+      name: {{ include "containerdConfigSecretName" $ }}
       key: registry-config.toml
 {{- end -}}
 
@@ -240,7 +240,7 @@ Generate name of the k8s secret that contains containerd configuration for regis
 When there is a change in the secret, it is not recognized by CAPI controllers.
 To enforce upgrades, a version suffix is appended to secret name.
 */}}
-{{- define "registrySecretName" -}}
+{{- define "containerdConfigSecretName" -}}
 {{- $secretSuffix := tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote | sha1sum | trunc 8 }}
 {{- include "resource.default.name" $ }}-registry-configuration-{{$secretSuffix}}
 {{- end -}}

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -118,7 +118,7 @@ joinConfiguration:
 files:
 {{- include "ntpFiles" . | nindent 2}}
 {{- include "sshFiles" . | nindent 2}}
-{{- include "registryFiles" . | nindent 2 }}
+{{- include "containerdConfig" . | nindent 2 }}
 {{- if $.Values.connectivity.proxy.enabled }}
 {{- include "containerdProxyConfig" . | nindent 2}}
 {{- end }}
@@ -224,53 +224,15 @@ taints:
 
 {{/*
 Generate a stanza for KubeAdmConfig and KubeAdmControlPlane in order to 
-mount containerd configuration for registry configuration in nodes.
+mount containerd configuration.
 */}}
-{{- define "registryFiles" -}}
-{{- if and .Values.connectivity .Values.connectivity.containerRegistries -}}
+{{- define "containerdConfig" -}}
 - path: /etc/containerd/conf.d/registry-config.toml
   permissions: "0600"
   contentFrom:
     secret:
       name: {{ include "registrySecretName" $ }}
       key: registry-config.toml
-{{- end -}}
-{{- end -}}
-
-{{/*
-Generate the content of /etc/containerd/conf.d/registry-config.toml in nodes
-for registry configuration
-*/}}
-{{- define "registrySecretContent" -}}
-version = 2
-
-[plugins."io.containerd.grpc.v1.cri".registry]
-
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-{{- range $registry, $mirrors := .Values.connectivity.containerRegistries}}
-
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$registry}}"]
-{{- $endpoints := list -}}
-{{- range $mirrors }}{{- $endpoints = append $endpoints .endpoint }}{{- end }}
-endpoint = [ "{{join "\" , \"" $endpoints}}" ]
-
-{{- end }}
-
-[plugins."io.containerd.grpc.v1.cri".registry.configs]
-
-{{- range $registry, $mirrors := .Values.connectivity.containerRegistries}}
-{{- range $mirrors }}
-
-{{- if .credentials }}
-[plugins."io.containerd.grpc.v1.cri".registry.configs."{{.endpoint}}".auth]
-{{- range $key, $value := .credentials }}
-{{ $key}}={{$value |quote}}
-{{- end }}
-{{ end }}
-
-{{- end }}
-{{- end }}
-
 {{- end -}}
 
 {{/*
@@ -279,7 +241,7 @@ When there is a change in the secret, it is not recognized by CAPI controllers.
 To enforce upgrades, a version suffix is appended to secret name.
 */}}
 {{- define "registrySecretName" -}}
-{{- $secretSuffix := include "registrySecretContent" . | b64enc | quote | sha1sum | trunc 8 }}
+{{- $secretSuffix := tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote | sha1sum | trunc 8 }}
 {{- include "resource.default.name" $ }}-registry-configuration-{{$secretSuffix}}
 {{- end -}}
 

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -227,7 +227,7 @@ Generate a stanza for KubeAdmConfig and KubeAdmControlPlane in order to
 mount containerd configuration.
 */}}
 {{- define "containerdConfig" -}}
-- path: /etc/containerd/conf.d/registry-config.toml
+- path: /etc/containerd/config.toml
   permissions: "0600"
   contentFrom:
     secret:

--- a/helm/cluster-cloud-director/templates/containerd-config-secret.yaml
+++ b/helm/cluster-cloud-director/templates/containerd-config-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "registrySecretName" $ }}
+  name: {{ include "containerdConfigSecretName" $ }}
 data:
   registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -139,7 +139,7 @@ spec:
       {{- include "containerdProxyConfig" . | nindent 6 }}
       {{- end }}
       {{- include "kubeadmFiles" . | nindent 6 }}
-      {{- include "registryFiles" . | nindent 6 }}
+      {{- include "containerdConfig" . | nindent 6 }}
       {{- range $kubeadmPatch, $_ :=  .Files.Glob  "files/etc/patches/**" }}
       - path: {{ (printf "/tmp/kubeadm/patches/%s" (base $kubeadmPatch)) }}
         content: |-

--- a/helm/cluster-cloud-director/templates/registry-secret.yaml
+++ b/helm/cluster-cloud-director/templates/registry-secret.yaml
@@ -1,8 +1,6 @@
-{{- if and .Values.connectivity .Values.connectivity.containerRegistries -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "registrySecretName" $ }}
 data:
   registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}
-{{- end -}}

--- a/helm/cluster-cloud-director/templates/registry-secret.yaml
+++ b/helm/cluster-cloud-director/templates/registry-secret.yaml
@@ -4,5 +4,5 @@ kind: Secret
 metadata:
   name: {{ include "registrySecretName" $ }}
 data:
-  registry-config.toml: {{ include "registrySecretContent" . | b64enc | quote }}
+  registry-config.toml: {{ tpl ($.Files.Get "files/etc/containerd/config.toml") $ | b64enc | quote }}
 {{- end -}}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -195,7 +195,8 @@
                                 }
                             }
                         }
-                    }
+                    },
+                    "default": {}
                 },
                 "network": {
                     "type": "object",
@@ -670,6 +671,27 @@
                     "type": "string",
                     "title": "Runtime defined entity (RDE) identifier",
                     "description": "This cluster's RDE ID in the VCD API."
+                },
+                "sandboxContainerImage": {
+                    "type": "object",
+                    "title": "Sandbox Container image",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Repository",
+                            "default": "tkg/pause"
+                        },
+                        "registry": {
+                            "type": "string",
+                            "title": "Registry",
+                            "default": "projects.registry.vmware.com/"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "title": "Tag",
+                            "default": "3.7"
+                        }
+                    }
                 },
                 "skipRde": {
                     "type": "boolean",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -674,7 +674,7 @@
                 },
                 "sandboxContainerImage": {
                     "type": "object",
-                    "title": "Sandbox Container image",
+                    "title": "Sandbox Container image (pause container)",
                     "properties": {
                         "name": {
                             "type": "string",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -679,17 +679,17 @@
                         "name": {
                             "type": "string",
                             "title": "Repository",
-                            "default": "tkg/pause"
+                            "default": "giantswarm/pause"
                         },
                         "registry": {
                             "type": "string",
                             "title": "Registry",
-                            "default": "projects.registry.vmware.com/"
+                            "default": "quay.io"
                         },
                         "tag": {
                             "type": "string",
                             "title": "Tag",
-                            "default": "3.7"
+                            "default": "3.9"
                         }
                     }
                 },

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -2,6 +2,7 @@
 
 baseDomain: k8s.test
 connectivity:
+  containerRegistries: {}
   network:
     controlPlaneEndpoint:
       port: 6443
@@ -55,6 +56,10 @@ internal:
         name: ExpandPersistentVolumes
       - enabled: true
         name: TTLAfterFinished
+  sandboxContainerImage:
+    name: tkg/pause
+    registry: projects.registry.vmware.com/
+    tag: "3.7"
   useAsManagementCluster: false
 kubectlImage:
   name: giantswarm/kubectl

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -57,9 +57,9 @@ internal:
       - enabled: true
         name: TTLAfterFinished
   sandboxContainerImage:
-    name: tkg/pause
-    registry: projects.registry.vmware.com/
-    tag: "3.7"
+    name: giantswarm/pause
+    registry: quay.io
+    tag: "3.9"
   useAsManagementCluster: false
 kubectlImage:
   name: giantswarm/kubectl


### PR DESCRIPTION
This PR:

- Consolidate the full `config.toml` configuration file for containerd into a single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)

@erkanerol as discussed in https://gigantic.slack.com/archives/C01BYMF6RN0/p1689847741604689?thread_ts=1689844311.988129&cid=C01BYMF6RN0 can you verify it when using the `credentials and mirrors` configurations ? the structure of values has not changed for those settings

### Testing

Description on how {APP-NAME} can be tested.

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.
