### PR TITLE
add user nobody to root group to enable node-exporter's filesystem collection to access the host filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - :boom: **Breaking:** Stop deploying default network policies with the `cilium-app`. This means the cluster will be more locked down and all network traffic is blocked by default. Can be disabled with `network.allowAllEgress` setting.
 - Consolidate containerd `config.toml` into a single file to address [#1737](https://github.com/giantswarm/roadmap/issues/1737)
+- Add host OS user `nobody` to `root` group to enable node-exporter's `filesystem` collector to access the host filesystem.
 
 ## [0.12.2] - 2023-07-03
 

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -140,6 +140,7 @@ preKubeadmCommands:
 postKubeadmCommands:
 {{ include "sshPostKubeadmCommands" . }}
 {{- include "ntpPostKubeadmCommands" . }}
+- usermod -aG root nobody # required for node-exporter to access the host's filesystem
 
 {{- end }}
 


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->
towards https://github.com/giantswarm/giantswarm/issues/27037

This PR:

- adds user `nobody` to group `root` to allow node-exporter to access the host's filesystem. 

this aligns with CAPA.

### Checklist

- [x] Update changelog in CHANGELOG.md.
