### PR TITLE
Lock everything by default in giantswarm and kube-system namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Lock network traffic by default in `giantswarm` and `kube-system` namespaces (default deny).
 - Remove `TTLAfterFinished` flag for Kubernetes 1.25 compatibility (enabled by default).
 - Remove `ExpandPersistentVolumes` flag for Kubernetes 1.27 compatibility (enabled by default).
 - Remove `logtostderr` for Kubernetes 1.27 compatibility (output is logged to stderr by default).

--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -109,7 +109,7 @@ spec:
                 kubectl patch -n ${NAMESPACE} helmrelease "${release}" --type=merge -p '{"metadata": {"finalizers": []}}'
               done
 
-              for chart in $(kubectl get HelmChart -n ${NAMESPACE} -o json | jq -r ".items[] | select(.spec.sourceRef.name == \"${CLUSTER_NAME}-default\") | .metadata.name"); do
+              for chart in $(kubectl get HelmChart -n ${NAMESPACE} -o json | jq -r ".items[] | select(.spec.sourceRef.name == \"${CLUSTER_NAME}-default\" or .spec.sourceRef.name == \"${CLUSTER_NAME}-cluster\") | .metadata.name"); do
                 echo "Patching helmchart $chart to remove finalizers"
                 kubectl patch -n ${NAMESPACE} helmchart "${chart}" --type=merge -p '{"metadata": {"finalizers": []}}'
                 echo "Deleting helmchart $chart"

--- a/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
@@ -1,0 +1,48 @@
+{{- if not .Values.connectivity.network.allowAllEgress }}
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: {{ include "resource.default.name" $ }}-network-policies
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  releaseName: network-policies
+  targetNamespace: kube-system
+  storageNamespace: kube-system
+  chart:
+    spec:
+      chart: network-policies
+      version: 0.0.3
+      sourceRef:
+        kind: HelmRepository
+        name: {{ include "resource.default.name" $ }}-cluster
+  dependsOn:
+    - name: {{ include "resource.default.name" $ }}-cilium
+      namespace: {{ $.Release.Namespace }}
+  kubeConfig:
+    secretRef:
+      name: {{ include "resource.default.name" $ }}-kubeconfig
+  interval: {{ ((.Values.helmReleases).coredns).interval | default "10m" }}
+  install:
+    remediation:
+      retries: 30
+  # Default values
+  # https://github.com/giantswarm/network-policies-app/blob/main/helm/network-policies-app/values.yaml
+  # values:
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: {{ include "resource.default.name" $ }}-cluster
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    cluster.giantswarm.io/description: "{{ .Values.clusterDescription }}"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  interval: 10m
+  url: https://giantswarm.github.io/cluster-catalog
+{{- end }}


### PR DESCRIPTION
issue: https://github.com/giantswarm/roadmap/issues/2815

This pr: installs network-policies-app as a HelmRelease that will effectively lock all the communication to `giantswarm` and `kube-system` namespaces

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
