### PR TITLE
Add CNPs to hook jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CiliumNetworkPolicies
+
 ## [0.14.1] - 2024-01-18
 
 ### Added

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -14,6 +14,8 @@ Properties within the `.internal` top-level object
 | `internal.apiServer.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
 | `internal.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|
 | `internal.apiServer.featureGates[*].name` | **Name**|**Type:** `string`<br/>**Example:** `"UserNamespacesStatelessPodsSupport"`<br/>**Value pattern:** `^[A-Za-z0-9]+$`<br/>|
+| `internal.ciliumNetworkPolicy` | **CiliumNetworkPolicies**|**Type:** `object`<br/>|
+| `internal.ciliumNetworkPolicy.enabled` | **Enable CiliumNetworkPolicies** - Installs the network-policies-app (deny all by default) if set to true|**Type:** `boolean`<br/>**Default:** `true`|
 | `internal.controllerManager` | **Controller manager**|**Type:** `object`<br/>|
 | `internal.controllerManager.featureGates` | **Feature gates** - Controller manager feature gate activation/deactivation.|**Type:** `array`<br/>**Default:** `[]`|
 | `internal.controllerManager.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
@@ -45,7 +47,6 @@ Configurations related to cluster connectivity such as container registries.
 | `connectivity.containerRegistries.*[*].credentials.username` | **Username** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
 | `connectivity.containerRegistries.*[*].endpoint` | **Endpoint** - Endpoint for the container registry.|**Type:** `string`<br/>|
 | `connectivity.network` | **Network**|**Type:** `object`<br/>|
-| `connectivity.network.allowAllEgress` | **Allow all egress** - When set to true default permisive CiliumNetworkPolicy CRs are installed. See https://github.com/giantswarm/cilium-app/blob/v0.10.0/helm/cilium/values.yaml#L2453.|**Type:** `boolean`<br/>**Default:** `false`|
 | `connectivity.network.controlPlaneEndpoint` | **Control plane endpoint** - Kubernetes API endpoint.|**Type:** `object`<br/>|
 | `connectivity.network.controlPlaneEndpoint.host` | **Host**|**Type:** `string`<br/>|
 | `connectivity.network.controlPlaneEndpoint.port` | **Port number**|**Type:** `integer`<br/>**Default:** `6443`|

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
             effect: "NoSchedule"
             operator: "Equal"
             value: "true"
-{{- if .Values.connectivity.network.allowAllEgress }}
+{{- if .Values.internal.ciliumNetworkPolicy }}
     defaultPolicies:
       enabled: true
       tolerations:

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
             effect: "NoSchedule"
             operator: "Equal"
             value: "true"
-{{- if .Values.internal.ciliumNetworkPolicy }}
+{{- if .Values.internal.ciliumNetworkPolicy.enabled }}
     defaultPolicies:
       enabled: true
       tolerations:

--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -88,6 +88,7 @@ spec:
       namespace: "{{ $.Release.Namespace }}"
       labels:
         {{- include "labels.common" $ | nindent 8 }}
+        cnp: {{ include "resource.default.name" $ }}-cleanup-helmreleases-hook
     spec:
       restartPolicy: Never
       serviceAccountName: "{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook"
@@ -124,3 +125,26 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "100m"
+{{- if not .Values.connectivity.network.allowAllEgress }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  name: "allow-{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook-kubernetes-talk-to-apiserver"
+  namespace: "{{ $.Release.Namespace }}"
+spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP
+      - port: "6443"
+        protocol: TCP
+  endpointSelector:
+    matchLabels:
+      cnp: {{ include "resource.default.name" $ }}-cleanup-helmreleases-hook
+{{- end }}

--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -125,14 +125,13 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "100m"
-{{- if not .Values.connectivity.network.allowAllEgress }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
-  name: "allow-{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook-kubernetes-talk-to-apiserver"
+  name: "allow-{{ include "resource.default.name" $ }}-cleanup-helmreleases-hook-to-apiserver"
   namespace: "{{ $.Release.Namespace }}"
 spec:
   egress:
@@ -147,4 +146,3 @@ spec:
   endpointSelector:
     matchLabels:
       cnp: {{ include "resource.default.name" $ }}-cleanup-helmreleases-hook
-{{- end }}

--- a/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.connectivity.network.allowAllEgress }}
+{{- if .Values.internal.ciliumNetworkPolicy }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:

--- a/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.internal.ciliumNetworkPolicy }}
+{{- if .Values.internal.ciliumNetworkPolicy.enabled }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:

--- a/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
@@ -86,6 +86,7 @@ spec:
       namespace: "{{ $.Release.Namespace }}"
       labels:
         {{- include "labels.common" $ | nindent 8 }}
+        cnp: "{{ include "resource.default.name" $ }}-pre-upgrade-suspend-hook"
     spec:
       restartPolicy: Never
       serviceAccountName: "{{ include "resource.default.name" $ }}-update-values-hook"
@@ -129,6 +130,7 @@ spec:
       namespace: "{{ $.Release.Namespace }}"
       labels:
         {{- include "labels.common" $ | nindent 8 }}
+        cnp: "{{ include "resource.default.name" $ }}-update-values-hook"
     spec:
       restartPolicy: Never
       serviceAccountName: "{{ include "resource.default.name" $ }}-update-values-hook"
@@ -156,3 +158,47 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "100m"
+{{- if not .Values.connectivity.network.allowAllEgress }}
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  name: "allow-{{ include "resource.default.name" $ }}-update-values-hook-kubernetes-talk-to-apiserver"
+  namespace: "{{ $.Release.Namespace }}"
+spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP
+      - port: "6443"
+        protocol: TCP
+  endpointSelector:
+    matchLabels:
+      cnp: {{ include "resource.default.name" $ }}-update-values-hook
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
+  name: "allow-{{ include "resource.default.name" $ }}-pre-upgrade-suspend-hook-kubernetes-talk-to-apiserver"
+  namespace: "{{ $.Release.Namespace }}"
+spec:
+  egress:
+  - toEntities:
+    - kube-apiserver
+    toPorts:
+    - ports:
+      - port: "443"
+        protocol: TCP
+      - port: "6443"
+        protocol: TCP
+  endpointSelector:
+    matchLabels:
+      cnp: {{ include "resource.default.name" $ }}-pre-upgrade-suspend-hook
+{{- end }}

--- a/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
@@ -158,14 +158,13 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "100m"
-{{- if not .Values.connectivity.network.allowAllEgress }}
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
-  name: "allow-{{ include "resource.default.name" $ }}-update-values-hook-kubernetes-talk-to-apiserver"
+  name: "allow-{{ include "resource.default.name" $ }}-update-values-hook-to-apiserver"
   namespace: "{{ $.Release.Namespace }}"
 spec:
   egress:
@@ -186,7 +185,7 @@ kind: CiliumNetworkPolicy
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
-  name: "allow-{{ include "resource.default.name" $ }}-pre-upgrade-suspend-hook-kubernetes-talk-to-apiserver"
+  name: "allow-{{ include "resource.default.name" $ }}-pre-upgrade-suspend-hook-to-apiserver"
   namespace: "{{ $.Release.Namespace }}"
 spec:
   egress:
@@ -201,4 +200,3 @@ spec:
   endpointSelector:
     matchLabels:
       cnp: {{ include "resource.default.name" $ }}-pre-upgrade-suspend-hook
-{{- end }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -208,12 +208,6 @@
                     ],
                     "additionalProperties": false,
                     "properties": {
-                        "allowAllEgress": {
-                            "type": "boolean",
-                            "title": "Allow all egress",
-                            "description": "When set to true default permisive CiliumNetworkPolicy CRs are installed. See https://github.com/giantswarm/cilium-app/blob/v0.10.0/helm/cilium/values.yaml#L2453.",
-                            "default": false
-                        },
                         "controlPlaneEndpoint": {
                             "type": "object",
                             "title": "Control plane endpoint",
@@ -654,6 +648,18 @@
                                 "$ref": "#/$defs/featureGate"
                             },
                             "default": []
+                        }
+                    }
+                },
+                "ciliumNetworkPolicy": {
+                    "type": "object",
+                    "title": "CiliumNetworkPolicies",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "title": "Enable CiliumNetworkPolicies",
+                            "description": "Installs the network-policies-app (deny all by default) if set to true",
+                            "default": true
                         }
                     }
                 },

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -4,7 +4,6 @@ baseDomain: k8s.test
 connectivity:
   containerRegistries: {}
   network:
-    allowAllEgress: false
     controlPlaneEndpoint:
       port: 6443
     loadBalancers: {}
@@ -49,6 +48,8 @@ internal:
       - ServiceAccount
       - ValidatingAdmissionWebhook
     featureGates: []
+  ciliumNetworkPolicy:
+    enabled: true
   controllerManager:
     featureGates: []
   sandboxContainerImage:


### PR DESCRIPTION
Pods from the helmrelease hook jobs fails to reach the K8s API.

I needed to add an extra label as a label named `job-name` fails to get picked up by the endpoint selector.

https://gigantic.slack.com/archives/CLPMFRVU6/p1706112803756279?thread_ts=1706112616.784229&cid=CLPMFRVU6

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how {APP-NAME} can be tested.

- [x] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for {APP-NAME} installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Update `/examples` if required.
