### PR TITLE
Expose cilium policy audit mode

### DIFF
--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -14,8 +14,10 @@ Properties within the `.internal` top-level object
 | `internal.apiServer.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
 | `internal.apiServer.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|
 | `internal.apiServer.featureGates[*].name` | **Name**|**Type:** `string`<br/>**Example:** `"UserNamespacesStatelessPodsSupport"`<br/>**Value pattern:** `^[A-Za-z0-9]+$`<br/>|
-| `internal.ciliumNetworkPolicy` | **CiliumNetworkPolicies**|**Type:** `object`<br/>|
-| `internal.ciliumNetworkPolicy.enabled` | **Enable CiliumNetworkPolicies** - Installs the network-policies-app (deny all by default) if set to true|**Type:** `boolean`<br/>**Default:** `true`|
+| `internal.cilium` | **Cilium configuration**|**Type:** `object`<br/>|
+| `internal.cilium.networkPolicy` | **Network Policies**|**Type:** `object`<br/>|
+| `internal.cilium.networkPolicy.enabled` | **Enable CiliumNetworkPolicies** - Installs the network-policies-app (deny all by default) if set to true|**Type:** `boolean`<br/>**Default:** `true`|
+| `internal.cilium.policyAuditMode` | **Enable Cilium policyAuditMode** - Enables or disables Audit Mode.|**Type:** `boolean`<br/>**Default:** `false`|
 | `internal.controllerManager` | **Controller manager**|**Type:** `object`<br/>|
 | `internal.controllerManager.featureGates` | **Feature gates** - Controller manager feature gate activation/deactivation.|**Type:** `array`<br/>**Default:** `[]`|
 | `internal.controllerManager.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -61,7 +61,8 @@ spec:
             effect: "NoSchedule"
             operator: "Equal"
             value: "true"
-{{- if .Values.internal.ciliumNetworkPolicy.enabled }}
+    policyAuditMode: {{ .Values.internal.cilium.policyAuditMode }}
+{{- if .Values.internal.cilium.networkPolicy.enabled }}
     defaultPolicies:
       enabled: true
       tolerations:

--- a/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.internal.ciliumNetworkPolicy.enabled }}
+{{- if .Values.internal.cilium.networkPolicy.enabled }}
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -651,15 +651,27 @@
                         }
                     }
                 },
-                "ciliumNetworkPolicy": {
+                "cilium": {
                     "type": "object",
-                    "title": "CiliumNetworkPolicies",
+                    "title": "Cilium configuration",
                     "properties": {
-                        "enabled": {
+                        "networkPolicy": {
+                            "type": "object",
+                            "title": "Network Policies",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable CiliumNetworkPolicies",
+                                    "description": "Installs the network-policies-app (deny all by default) if set to true",
+                                    "default": true
+                                }
+                            }
+                        },
+                        "policyAuditMode": {
                             "type": "boolean",
-                            "title": "Enable CiliumNetworkPolicies",
-                            "description": "Installs the network-policies-app (deny all by default) if set to true",
-                            "default": true
+                            "title": "Enable Cilium policyAuditMode",
+                            "description": "Enables or disables Audit Mode.",
+                            "default": false
                         }
                     }
                 },

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -48,8 +48,10 @@ internal:
       - ServiceAccount
       - ValidatingAdmissionWebhook
     featureGates: []
-  ciliumNetworkPolicy:
-    enabled: true
+  cilium:
+    networkPolicy:
+      enabled: true
+    policyAuditMode: false
   controllerManager:
     featureGates: []
   sandboxContainerImage:


### PR DESCRIPTION
Towards enabling network whitelisting in customer clusters we can expect a few hiccups. Context: We had issues with a customer that had keycloak broken because of it and rolled back default apps to fix it (which introduced other problems).

I propose to offer the possibility to turn on audit mode so we can switch to white listing in 2 steps:

-   `internal.cilium.policyAuditMode: true` + `internal.cilium.networkPolicy.enabled: true`  =  The deny all policies are installed in audit mode. Customer (and GS) can figure out additional rules needed.
-   `internal.cilium.policyAuditMode: false` + `internal.cilium.networkPolicy.enabled: true`  =  The deny all policies "enforce" once previous step is complete.

