### PR TITLE
Only create Cilium resources if Cilium CRDs exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Only create Cilium resources if Cilium CRDs exist.
+
 ## [0.14.5] - 2024-02-14
 
 ### Changed

--- a/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/cleanup-helmreleases-hook-job.yaml
@@ -126,6 +126,7 @@ spec:
               memory: "256Mi"
               cpu: "100m"
 ---
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2" -}}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -150,3 +151,4 @@ spec:
   endpointSelector:
     matchLabels:
       cnp: {{ include "resource.default.name" $ }}-cleanup-helmreleases-hook
+{{- end }}

--- a/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
+++ b/helm/cluster-cloud-director/templates/update-values-hook-job.yaml
@@ -159,6 +159,7 @@ spec:
               memory: "256Mi"
               cpu: "100m"
 ---
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2" -}}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -200,3 +201,4 @@ spec:
   endpointSelector:
     matchLabels:
       cnp: {{ include "resource.default.name" $ }}-pre-upgrade-suspend-hook
+{{- end }}


### PR DESCRIPTION
This PR:

- only creates Cilium resources if Cilium CRDs exist

This is necessary because the bootstrap cluster (kind, vcluster) doesn't run Cilium, so chart installation fails.

### Checklist

- [x] Update changelog in CHANGELOG.md.
