### PR TITLE
Bump kubectl image to 1.25.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `kubectl` image to `1.25.15`.
+
 ## [0.15.0] - 2024-03-08
 
 ### Changed

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -126,7 +126,7 @@ Used by cluster-shared library chart to configure coredns in-cluster.
 | :----------- | :-------------- | :--------------- |
 | `kubectlImage.name` | **Repository**|**Type:** `string`<br/>**Default:** `"giantswarm/kubectl"`|
 | `kubectlImage.registry` | **Registry**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io"`|
-| `kubectlImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.23.5"`|
+| `kubectlImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.25.15"`|
 
 ### Metadata
 Properties within the `.metadata` top-level object

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -763,7 +763,7 @@
                 "tag": {
                     "type": "string",
                     "title": "Tag",
-                    "default": "1.23.5"
+                    "default": "1.25.15"
                 }
             }
         },

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -63,7 +63,7 @@ internal:
 kubectlImage:
   name: giantswarm/kubectl
   registry: gsoci.azurecr.io
-  tag: 1.23.5
+  tag: 1.25.15
 metadata:
   preventDeletion: false
   servicePriority: highest


### PR DESCRIPTION
This PR:

- bumps kubectl image to 1.25.15 to avoid version skew with cluster version.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
