### PR TITLE
Set a default nodeclass, nodepool, Flatcar and kubernetesVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed schema to include a default nodeClass `default` used by a default nodePool `worker`. Customers and GS currently set these so they will be overwritten. These defaults are to be used by E2E tests.
+
 ## [0.16.0] - 2024-04-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed schema to include a default nodeClass `default` used by a default nodePool `worker`. Customers and GS currently set these so they will be overwritten. These defaults are to be used by E2E tests.
+- Changed schema to include a default nodeClass `default` used by a default nodePool `worker`. Customers and GS currently set these so they will be overwritten. These defaults are to be used by E2E tests. Other settings are defaulted in the chart such as Kubernetes version, VM template, catalog...
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This repository contains the Helm chart used for deploying CAPI clusters via [CA
 - `cilium` as CNI in `kube-proxy` replacement mode (see [Limitations](#Limitations) section below)
 - CPI and CSI for VMware Cloud Director
 
+## Cluster app components versions (defaults)
+
+| Cluster App Version | Kubernetes version | Flatcar Version | vApp Template Name | CPI / CSI | Comment |
+| ------------------- | ------------------ | --------------- | ------------------ | ----------- | ------- |
+| Update in release PR | v1.25.16        | 3602.2.1        | flatcar-stable-3602.2.1-kube-v1.25.16 | 1.2.0 / 1.3.2 |
+
 ## Authentication to VCD
 
 Authentication to the VCD API is achieved as part of the cluster creation process to abide by user-defined resource quotas. It can be achieved by referencing a secret (preferred method) or specifying creds/token in the VCDCluster definition. **We only support referencing a secret in this app**.

--- a/README.md
+++ b/README.md
@@ -100,3 +100,28 @@ k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.baseDomai
 You can see it in [cilium-helmrelease.yaml](helm/cluster-cloud-director/templates/cilium-helmrelease.yaml).
 
 This means cluster nodes won't come up Ready before this domain is set to the IP of the Kubernetes API server (it's defined in the `Cluster` CR under `.spec.controlPlaneEndpoint.host`). In Giant Swarm clusters we use [dns-operator-route53](https://github.com/giantswarm/dns-operator-route53) to create the records (public DNS resolution is then required).
+
+## Update chart's schema docs
+
+After making a change to the schema, run `schemadocs` to update the README documentation.
+
+https://github.com/giantswarm/schemadocs
+
+```yaml
+VALUES_SCHEMA=$(find ./helm -maxdepth 2 -name values.schema.json)
+CHART_README=$(find ./helm -maxdepth 2 -name README.md)
+
+schemadocs generate $VALUES_SCHEMA -o $CHART_README
+```
+
+## Generate values from schema
+
+Do not make changes to the `values.yaml` file manually. That file should be automatically generated from the schema.
+
+https://github.com/giantswarm/helm-values-gen
+
+```yaml
+cd helm/cluster-cloud-director
+
+helm-values-gen values.schema.json -o values.yaml -f
+```

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -89,7 +89,7 @@ Properties within the `.controlPlane` top-level object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `controlPlane.catalog` | **Catalog** - Name of the VCD catalog in which the VM template is stored.|**Type:** `string`<br/>**Example:** `"giantswarm"`<br/>|
+| `controlPlane.catalog` | **Catalog** - Name of the VCD catalog in which the VM template is stored.|**Type:** `string`<br/>**Default:** `"giantswarm"`|
 | `controlPlane.certSANs` | **Subject alternative names (SAN)** - Alternative names to encode in the API server's certificate.|**Type:** `array`<br/>|
 | `controlPlane.certSANs[*]` | **SAN**|**Type:** `string`<br/>|
 | `controlPlane.customNodeLabels` | **Node labels**|**Type:** `array`<br/>|
@@ -116,7 +116,7 @@ Properties within the `.controlPlane` top-level object
 | `controlPlane.resourceRatio` | **Resource ratio** - Ratio between node resources and apiserver resource requests.|**Type:** `integer`<br/>**Default:** `8`|
 | `controlPlane.sizingPolicy` | **Sizing policy** - Name of the VCD sizing policy to use.|**Type:** `string`<br/>**Example:** `"m1.medium"`<br/>|
 | `controlPlane.storageProfile` | **Storage profile** - Name of the VCD storage profile to use.|**Type:** `string`<br/>|
-| `controlPlane.template` | **Template** - Name of the template used to create the node VMs.|**Type:** `string`<br/>**Example:** `"ubuntu-2004-kube-v1.22.5"`<br/>|
+| `controlPlane.template` | **Template** - Name of the template used to create the node VMs.|**Type:** `string`<br/>**Default:** `"flatcar-stable-3602.2.1-kube-v1.25.16"`|
 
 ### Kubectl image
 Properties within the `.kubectlImage` top-level object
@@ -149,6 +149,9 @@ Groups of worker nodes with identical configuration.
 | `nodePools.PATTERN` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>|
 | `nodePools.PATTERN.class` | **Node class** - A valid node class name, as specified in VMware Cloud Director (VCD) settings > Node classes.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>**Value pattern:** `^[a-z0-9-]+$`<br/>|
 | `nodePools.PATTERN.replicas` | **Number of nodes**|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>**Default:** `1`|
+| `nodePools.worker` |**None**|**Type:** `object`<br/>|
+| `nodePools.worker.class` | **Node class** - A valid node class name, as specified in VMware Cloud Director (VCD) settings > Node classes.|**Type:** `string`<br/>**Default:** `"default"`|
+| `nodePools.worker.replicas` | **Number of nodes**|**Type:** `integer`<br/>**Default:** `2`|
 
 ### Pod Security Standards
 Properties within the `.global.podSecurityStandards` object
@@ -177,7 +180,7 @@ Properties within the `.providerSpecific` top-level object
 | `providerSpecific.containerStorageInterface.storageClass.retain.vcdStorageProfileName` | **Name of storage profile in VCD**|**Type:** `string`<br/>**Default:** `""`|
 | `providerSpecific.nodeClasses` | **Node classes** - Re-usable node configuration.|**Type:** `object`<br/>|
 | `providerSpecific.nodeClasses.PATTERN` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
-| `providerSpecific.nodeClasses.PATTERN.catalog` | **Catalog** - Name of the VCD catalog in which the VM template is stored.|**Type:** `string`<br/>**Example:** `"giantswarm"`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
+| `providerSpecific.nodeClasses.PATTERN.catalog` | **Catalog** - Name of the VCD catalog in which the VM template is stored.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>**Default:** `"giantswarm"`|
 | `providerSpecific.nodeClasses.PATTERN.customNodeLabels` | **Node labels**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.customNodeLabels[*]` | **Custom node label**|**Type:** `string`<br/>**Example:** `"key=value"`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>**Value pattern:** `^[A-Za-z0-9-_\./]{1,63}=[A-Za-z0-9-_\.]{0,63}$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.customNodeTaints` | **Node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
@@ -189,7 +192,21 @@ Properties within the `.providerSpecific` top-level object
 | `providerSpecific.nodeClasses.PATTERN.placementPolicy` | **VM placement policy** - Name of the VCD VM placement policy to use.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.sizingPolicy` | **Sizing policy** - Name of the VCD sizing policy to use.|**Type:** `string`<br/>**Example:** `"m1.medium"`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.storageProfile` | **Storage profile** - Name of the VCD storage profile to use.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
-| `providerSpecific.nodeClasses.PATTERN.template` | **Template** - Name of the template used to create the node VMs.|**Type:** `string`<br/>**Example:** `"ubuntu-2004-kube-v1.22.5"`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
+| `providerSpecific.nodeClasses.PATTERN.template` | **Template** - Name of the template used to create the node VMs.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>**Default:** `"flatcar-stable-3602.2.1-kube-v1.25.16"`|
+| `providerSpecific.nodeClasses.default` |**None**|**Type:** `object`<br/>|
+| `providerSpecific.nodeClasses.default.catalog` | **Catalog** - Name of the VCD catalog in which the VM template is stored.|**Type:** `string`<br/>**Default:** `"giantswarm"`|
+| `providerSpecific.nodeClasses.default.customNodeLabels` | **Node labels**|**Type:** `array`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeLabels[*]` | **Custom node label**|**Type:** `string`<br/>**Example:** `"key=value"`<br/>**Value pattern:** `^[A-Za-z0-9-_\./]{1,63}=[A-Za-z0-9-_\.]{0,63}$`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeTaints` | **Node taints**|**Type:** `array`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeTaints[*]` | **Custom node taint**|**Type:** `object`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeTaints[*].effect` |One of NoSchedule, PreferNoSchedule or NoExecute|**Type:** `string`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeTaints[*].key` |Name of the label on a node|**Type:** `string`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeTaints[*].value` |value of the label identified by the key|**Type:** `string`<br/>|
+| `providerSpecific.nodeClasses.default.diskSizeGB` | **Disk size**|**Type:** `integer`<br/>**Example:** `30`<br/>|
+| `providerSpecific.nodeClasses.default.placementPolicy` | **VM placement policy** - Name of the VCD VM placement policy to use.|**Type:** `string`<br/>|
+| `providerSpecific.nodeClasses.default.sizingPolicy` | **Sizing policy** - Name of the VCD sizing policy to use.|**Type:** `string`<br/>**Example:** `"m1.medium"`<br/>|
+| `providerSpecific.nodeClasses.default.storageProfile` | **Storage profile** - Name of the VCD storage profile to use.|**Type:** `string`<br/>|
+| `providerSpecific.nodeClasses.default.template` | **Template** - Name of the template used to create the node VMs.|**Type:** `string`<br/>**Default:** `"flatcar-stable-3602.2.1-kube-v1.25.16"`|
 | `providerSpecific.org` | **Organization** - VCD organization name.|**Type:** `string`<br/>|
 | `providerSpecific.ovdc` | **OvDC name** - Name of the organization virtual datacenter (OvDC) to create this cluster in.|**Type:** `string`<br/>|
 | `providerSpecific.ovdcNetwork` | **OvDC network** - VCD network to connect VMs.|**Type:** `string`<br/>|

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -21,7 +21,7 @@ Properties within the `.internal` top-level object
 | `internal.controllerManager.featureGates[*]` | **Feature gate**|**Type:** `object`<br/>|
 | `internal.controllerManager.featureGates[*].enabled` | **Enabled**|**Type:** `boolean`<br/>|
 | `internal.controllerManager.featureGates[*].name` | **Name**|**Type:** `string`<br/>**Example:** `"UserNamespacesStatelessPodsSupport"`<br/>**Value pattern:** `^[A-Za-z0-9]+$`<br/>|
-| `internal.kubernetesVersion` | **Kubernetes version** - For cloud-init (Ubuntu), append the version with '+vmware.1'.|**Type:** `string`<br/>|
+| `internal.kubernetesVersion` | **Kubernetes version** - For cloud-init (Ubuntu), append the version with '+vmware.1'.|**Type:** `string`<br/>**Default:** `"v1.25.16"`|
 | `internal.parentUid` | **Management cluster UID** - If set, create the cluster from a specific management cluster associated with this UID.|**Type:** `string`<br/>|
 | `internal.rdeId` | **Runtime defined entity (RDE) identifier** - This cluster's RDE ID in the VCD API.|**Type:** `string`<br/>|
 | `internal.sandboxContainerImage` | **Sandbox Container image (pause container)**|**Type:** `object`<br/>|

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -149,7 +149,7 @@ Groups of worker nodes with identical configuration.
 | `nodePools.PATTERN` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>|
 | `nodePools.PATTERN.class` | **Node class** - A valid node class name, as specified in VMware Cloud Director (VCD) settings > Node classes.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>**Value pattern:** `^[a-z0-9-]+$`<br/>|
 | `nodePools.PATTERN.replicas` | **Number of nodes**|**Type:** `integer`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]{3,10}$`<br/>**Default:** `1`|
-| `nodePools.worker` |**None**|**Type:** `object`<br/>|
+| `nodePools.worker` | **Default nodePool**|**Type:** `object`<br/>|
 | `nodePools.worker.class` | **Node class** - A valid node class name, as specified in VMware Cloud Director (VCD) settings > Node classes.|**Type:** `string`<br/>**Default:** `"default"`|
 | `nodePools.worker.replicas` | **Number of nodes**|**Type:** `integer`<br/>**Default:** `2`|
 
@@ -185,23 +185,23 @@ Properties within the `.providerSpecific` top-level object
 | `providerSpecific.nodeClasses.PATTERN.customNodeLabels[*]` | **Custom node label**|**Type:** `string`<br/>**Example:** `"key=value"`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>**Value pattern:** `^[A-Za-z0-9-_\./]{1,63}=[A-Za-z0-9-_\.]{0,63}$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.customNodeTaints` | **Node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.customNodeTaints[*]` | **Custom node taint**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
-| `providerSpecific.nodeClasses.PATTERN.customNodeTaints[*].effect` |One of NoSchedule, PreferNoSchedule or NoExecute|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
-| `providerSpecific.nodeClasses.PATTERN.customNodeTaints[*].key` |Name of the label on a node|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
-| `providerSpecific.nodeClasses.PATTERN.customNodeTaints[*].value` |value of the label identified by the key|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
+| `providerSpecific.nodeClasses.PATTERN.customNodeTaints[*].effect` | **Node taint effect** - One of NoSchedule, PreferNoSchedule or NoExecute.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
+| `providerSpecific.nodeClasses.PATTERN.customNodeTaints[*].key` | **Node taint key** - Name of the label on a node.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
+| `providerSpecific.nodeClasses.PATTERN.customNodeTaints[*].value` | **Node taint value** - Value of the label identified by the key.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.diskSizeGB` | **Disk size**|**Type:** `integer`<br/>**Example:** `30`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.placementPolicy` | **VM placement policy** - Name of the VCD VM placement policy to use.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.sizingPolicy` | **Sizing policy** - Name of the VCD sizing policy to use.|**Type:** `string`<br/>**Example:** `"m1.medium"`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.storageProfile` | **Storage profile** - Name of the VCD storage profile to use.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>|
 | `providerSpecific.nodeClasses.PATTERN.template` | **Template** - Name of the template used to create the node VMs.|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9-]+$`<br/>**Default:** `"flatcar-stable-3602.2.1-kube-v1.25.16"`|
-| `providerSpecific.nodeClasses.default` |**None**|**Type:** `object`<br/>|
+| `providerSpecific.nodeClasses.default` | **Default nodeClass**|**Type:** `object`<br/>|
 | `providerSpecific.nodeClasses.default.catalog` | **Catalog** - Name of the VCD catalog in which the VM template is stored.|**Type:** `string`<br/>**Default:** `"giantswarm"`|
 | `providerSpecific.nodeClasses.default.customNodeLabels` | **Node labels**|**Type:** `array`<br/>|
 | `providerSpecific.nodeClasses.default.customNodeLabels[*]` | **Custom node label**|**Type:** `string`<br/>**Example:** `"key=value"`<br/>**Value pattern:** `^[A-Za-z0-9-_\./]{1,63}=[A-Za-z0-9-_\.]{0,63}$`<br/>|
 | `providerSpecific.nodeClasses.default.customNodeTaints` | **Node taints**|**Type:** `array`<br/>|
 | `providerSpecific.nodeClasses.default.customNodeTaints[*]` | **Custom node taint**|**Type:** `object`<br/>|
-| `providerSpecific.nodeClasses.default.customNodeTaints[*].effect` |One of NoSchedule, PreferNoSchedule or NoExecute|**Type:** `string`<br/>|
-| `providerSpecific.nodeClasses.default.customNodeTaints[*].key` |Name of the label on a node|**Type:** `string`<br/>|
-| `providerSpecific.nodeClasses.default.customNodeTaints[*].value` |value of the label identified by the key|**Type:** `string`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeTaints[*].effect` | **Node taint effect** - One of NoSchedule, PreferNoSchedule or NoExecute.|**Type:** `string`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeTaints[*].key` | **Node taint key** - Name of the label on a node.|**Type:** `string`<br/>|
+| `providerSpecific.nodeClasses.default.customNodeTaints[*].value` | **Node taint value** - Value of the label identified by the key.|**Type:** `string`<br/>|
 | `providerSpecific.nodeClasses.default.diskSizeGB` | **Disk size**|**Type:** `integer`<br/>**Example:** `30`<br/>|
 | `providerSpecific.nodeClasses.default.placementPolicy` | **VM placement policy** - Name of the VCD VM placement policy to use.|**Type:** `string`<br/>|
 | `providerSpecific.nodeClasses.default.sizingPolicy` | **Sizing policy** - Name of the VCD sizing policy to use.|**Type:** `string`<br/>**Example:** `"m1.medium"`<br/>|

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -99,10 +99,10 @@ Properties within the `.controlPlane` top-level object
 | `controlPlane.dns.imageRepository` | **Repository**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io/giantswarm"`|
 | `controlPlane.dns.imageTag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.9.4-giantswarm"`|
 | `controlPlane.etcd` | **Etcd container image**|**Type:** `object`<br/>|
-| `controlPlane.etcd.imageRepository` | **Repository**|**Type:** `string`<br/>**Example:** `"gsoci.azurecr.io/giantswarm"`<br/>**Default:** `"gsoci.azurecr.io/giantswarm"`|
-| `controlPlane.etcd.imageTag` | **Tag**|**Type:** `string`<br/>**Example:** `"3.5.4-0-k8s"`<br/>**Default:** `"3.5.4-0-k8s"`|
-| `controlPlane.image` | **Node container image** - Set to 'giantswarm' for ignition (Flatcar) and 'projects.registry.vmware.com/tkg' for cloud-init (Ubuntu).|**Type:** `object`<br/>|
-| `controlPlane.image.repository` | **Repository**|**Type:** `string`<br/>**Default:** `"projects.registry.vmware.com/tkg"`|
+| `controlPlane.etcd.imageRepository` | **Repository**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io/giantswarm"`|
+| `controlPlane.etcd.imageTag` | **Tag**|**Type:** `string`<br/>**Default:** `"3.5.4-0-k8s"`|
+| `controlPlane.image` | **Node container image** - Set to 'gsoci.azurecr.io/giantswarm' for ignition (Flatcar) and 'projects.registry.vmware.com/tkg' for cloud-init (Ubuntu).|**Type:** `object`<br/>|
+| `controlPlane.image.repository` | **Repository**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io/giantswarm"`|
 | `controlPlane.oidc` | **OIDC authentication**|**Type:** `object`<br/>|
 | `controlPlane.oidc.caFile` | **Certificate authority file** - Path to identity provider's CA certificate in PEM format.|**Type:** `string`<br/>|
 | `controlPlane.oidc.clientId` | **Client ID** - OIDC client identifier to identify with.|**Type:** `string`<br/>|
@@ -214,7 +214,7 @@ Properties within the `.providerSpecific` top-level object
 | `providerSpecific.userContext` | **VCD API access token**|**Type:** `object`<br/>|
 | `providerSpecific.userContext.secretRef` | **Secret reference**|**Type:** `object`<br/>|
 | `providerSpecific.userContext.secretRef.secretName` | **Name** - Name of the secret containing the VCD API token.|**Type:** `string`<br/>|
-| `providerSpecific.vmBootstrapFormat` | **Ignition or cloud-init for OS initialization** - Select either 'ignition' for Flatcar or 'cloud-config' for other OSes (e.g. Ubuntu).|**Type:** `string`<br/>**Default:** `"cloud-config"`|
+| `providerSpecific.vmBootstrapFormat` | **Ignition or cloud-init for OS initialization** - Select either 'ignition' for Flatcar or 'cloud-config' for other OSes (e.g. Ubuntu).|**Type:** `string`<br/>**Default:** `"ignition"`|
 | `providerSpecific.vmNamingTemplate` | **VM naming template** - Go template to specify the VM naming convention.|**Type:** `string`<br/>**Example:** `"mytenant-{{ .machine.Name | sha256sum | trunc 7 }}"`<br/>|
 
 ### Other

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -225,7 +225,7 @@ postKubeadmCommands:
 
 {{- define "kubeadmConfigTemplateRevision" -}}
 {{- $inputs := (dict
-  "data" (include "kubeadmConfigTemplateSpec" .) ) }}
+  "data" (nospace (include "kubeadmConfigTemplateSpec" .)) ) }}
 {{- mustToJson $inputs | toString | quote | sha1sum | trunc 8 }}
 {{- end -}}
 

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -225,7 +225,7 @@ postKubeadmCommands:
 
 {{- define "kubeadmConfigTemplateRevision" -}}
 {{- $inputs := (dict
-  "data" (nospace (include "kubeadmConfigTemplateSpec" .)) ) }}
+  "data" (replace "\n\n" "\n" (include "kubeadmConfigTemplateSpec" .)) ) }}
 {{- mustToJson $inputs | toString | quote | sha1sum | trunc 8 }}
 {{- end -}}
 

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -71,7 +71,7 @@
                 "additionalProperties": false,
                 "properties": {
                     "effect": {
-                        "title": "node taint effect",
+                        "title": "Node taint effect",
                         "type": "string",
                         "description": "One of NoSchedule, PreferNoSchedule or NoExecute.",
                         "enum": [
@@ -81,13 +81,13 @@
                         ]
                     },
                     "key": {
-                        "title": "node taint key",
+                        "title": "Node taint key",
                         "type": "string",
                         "description": "Name of the label on a node.",
                         "minLength": 1
                     },
                     "value": {
-                        "title": "node taint value",
+                        "title": "Node taint value",
                         "type": "string",
                         "description": "Value of the label identified by the key."
                     }

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -465,8 +465,7 @@
                 "diskSizeGB": {
                     "$ref": "#/$defs/diskSizeGB",
                     "title": "Disk size",
-                    "description": "Control plane node root volume size, in GB.",
-                    "default": 30
+                    "description": "Control plane node root volume size, in GB."
                 },
                 "dns": {
                     "type": "object",
@@ -975,8 +974,7 @@
                                 },
                                 "diskSizeGB": {
                                     "$ref": "#/$defs/diskSizeGB",
-                                    "description": "Node root volume size, in GB.",
-                                    "default": 30
+                                    "description": "Node root volume size, in GB."
                                 },
                                 "placementPolicy": {
                                     "$ref": "#/$defs/placementPolicy"

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -5,9 +5,7 @@
             "type": "string",
             "title": "Catalog",
             "description": "Name of the VCD catalog in which the VM template is stored.",
-            "examples": [
-                "giantswarm"
-            ]
+            "default": "giantswarm"
         },
         "cidrBlocks": {
             "type": "array",
@@ -115,9 +113,7 @@
             "type": "string",
             "title": "Template",
             "description": "Name of the template used to create the node VMs.",
-            "examples": [
-                "ubuntu-2004-kube-v1.22.5"
-            ]
+            "default": "flatcar-stable-3602.2.1-kube-v1.25.16"
         }
     },
     "type": "object",
@@ -840,6 +836,26 @@
                         }
                     }
                 }
+            },
+            "properties": {
+                "worker": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "class": {
+                            "type": "string",
+                            "title": "Node class",
+                            "description": "A valid node class name, as specified in VMware Cloud Director (VCD) settings > Node classes.",
+                            "default": "default"
+                        },
+                        "replicas": {
+                            "type": "integer",
+                            "title": "Number of nodes",
+                            "default": 2,
+                            "minimum": 1
+                        }
+                    }
+                }
             }
         },
         "provider": {
@@ -965,6 +981,39 @@
                                     "$ref": "#/$defs/diskSizeGB",
                                     "description": "Node root volume size, in GB.",
                                     "default": 30
+                                },
+                                "placementPolicy": {
+                                    "$ref": "#/$defs/placementPolicy"
+                                },
+                                "sizingPolicy": {
+                                    "$ref": "#/$defs/sizingPolicy"
+                                },
+                                "storageProfile": {
+                                    "$ref": "#/$defs/storageProfile"
+                                },
+                                "template": {
+                                    "$ref": "#/$defs/template"
+                                }
+                            }
+                        }
+                    },
+                    "properties": {
+                        "default": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "catalog": {
+                                    "$ref": "#/$defs/catalog"
+                                },
+                                "customNodeLabels": {
+                                    "$ref": "#/$defs/nodeLabels"
+                                },
+                                "customNodeTaints": {
+                                    "$ref": "#/$defs/nodeTaints"
+                                },
+                                "diskSizeGB": {
+                                    "$ref": "#/$defs/diskSizeGB",
+                                    "description": "Node root volume size, in GB."
                                 },
                                 "placementPolicy": {
                                     "$ref": "#/$defs/placementPolicy"

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -71,8 +71,8 @@
                 "additionalProperties": false,
                 "properties": {
                     "effect": {
-                        "title": "Node taint effect",
                         "type": "string",
+                        "title": "Node taint effect",
                         "description": "One of NoSchedule, PreferNoSchedule or NoExecute.",
                         "enum": [
                             "NoSchedule",
@@ -81,14 +81,14 @@
                         ]
                     },
                     "key": {
-                        "title": "Node taint key",
                         "type": "string",
+                        "title": "Node taint key",
                         "description": "Name of the label on a node.",
                         "minLength": 1
                     },
                     "value": {
-                        "title": "Node taint value",
                         "type": "string",
+                        "title": "Node taint value",
                         "description": "Value of the label identified by the key."
                     }
                 }
@@ -842,8 +842,8 @@
             },
             "properties": {
                 "worker": {
-                    "title": "Default nodePool",
                     "type": "object",
+                    "title": "Default nodePool",
                     "additionalProperties": false,
                     "properties": {
                         "class": {
@@ -1003,8 +1003,8 @@
                     },
                     "properties": {
                         "default": {
-                            "title": "Default nodeClass",
                             "type": "object",
+                            "title": "Default nodeClass",
                             "additionalProperties": false,
                             "properties": {
                                 "catalog": {

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -71,8 +71,9 @@
                 "additionalProperties": false,
                 "properties": {
                     "effect": {
+                        "title": "node taint effect",
                         "type": "string",
-                        "description": "One of NoSchedule, PreferNoSchedule or NoExecute",
+                        "description": "One of NoSchedule, PreferNoSchedule or NoExecute.",
                         "enum": [
                             "NoSchedule",
                             "PreferNoSchedule",
@@ -80,13 +81,15 @@
                         ]
                     },
                     "key": {
+                        "title": "node taint key",
                         "type": "string",
-                        "description": "Name of the label on a node",
+                        "description": "Name of the label on a node.",
                         "minLength": 1
                     },
                     "value": {
+                        "title": "node taint value",
                         "type": "string",
-                        "description": "value of the label identified by the key"
+                        "description": "Value of the label identified by the key."
                     }
                 }
             }
@@ -839,6 +842,7 @@
             },
             "properties": {
                 "worker": {
+                    "title": "Default nodePool",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
@@ -999,6 +1003,7 @@
                     },
                     "properties": {
                         "default": {
+                            "title": "Default nodeClass",
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -493,17 +493,11 @@
                         "imageRepository": {
                             "type": "string",
                             "title": "Repository",
-                            "examples": [
-                                "gsoci.azurecr.io/giantswarm"
-                            ],
                             "default": "gsoci.azurecr.io/giantswarm"
                         },
                         "imageTag": {
                             "type": "string",
                             "title": "Tag",
-                            "examples": [
-                                "3.5.4-0-k8s"
-                            ],
                             "default": "3.5.4-0-k8s"
                         }
                     }
@@ -511,13 +505,13 @@
                 "image": {
                     "type": "object",
                     "title": "Node container image",
-                    "description": "Set to 'giantswarm' for ignition (Flatcar) and 'projects.registry.vmware.com/tkg' for cloud-init (Ubuntu).",
+                    "description": "Set to 'gsoci.azurecr.io/giantswarm' for ignition (Flatcar) and 'projects.registry.vmware.com/tkg' for cloud-init (Ubuntu).",
                     "additionalProperties": false,
                     "properties": {
                         "repository": {
                             "type": "string",
                             "title": "Repository",
-                            "default": "projects.registry.vmware.com/tkg"
+                            "default": "gsoci.azurecr.io/giantswarm"
                         }
                     }
                 },
@@ -1081,7 +1075,7 @@
                         "cloud-config",
                         "ignition"
                     ],
-                    "default": "cloud-config"
+                    "default": "ignition"
                 },
                 "vmNamingTemplate": {
                     "type": "string",

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -694,7 +694,8 @@
                 "kubernetesVersion": {
                     "type": "string",
                     "title": "Kubernetes version",
-                    "description": "For cloud-init (Ubuntu), append the version with '+vmware.1'."
+                    "description": "For cloud-init (Ubuntu), append the version with '+vmware.1'.",
+                    "default": "v1.25.16"
                 },
                 "parentUid": {
                     "type": "string",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -23,7 +23,6 @@ connectivity:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 controlPlane:
   catalog: giantswarm
-  diskSizeGB: 30
   dns:
     imageRepository: gsoci.azurecr.io/giantswarm
     imageTag: 1.9.4-giantswarm

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -57,6 +57,7 @@ internal:
     enabled: true
   controllerManager:
     featureGates: []
+  kubernetesVersion: v1.25.16
   sandboxContainerImage:
     name: giantswarm/pause
     registry: gsoci.azurecr.io

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -31,7 +31,7 @@ controlPlane:
     imageRepository: gsoci.azurecr.io/giantswarm
     imageTag: 3.5.4-0-k8s
   image:
-    repository: projects.registry.vmware.com/tkg
+    repository: gsoci.azurecr.io/giantswarm
   oidc: {}
   replicas: 1
   resourceRatio: 8
@@ -94,4 +94,4 @@ providerSpecific:
       template: flatcar-stable-3602.2.1-kube-v1.25.16
   userContext:
     secretRef: {}
-  vmBootstrapFormat: cloud-config
+  vmBootstrapFormat: ignition

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -22,6 +22,7 @@ connectivity:
     sshTrustedUserCAKeys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 controlPlane:
+  catalog: giantswarm
   diskSizeGB: 30
   dns:
     imageRepository: gsoci.azurecr.io/giantswarm
@@ -34,6 +35,7 @@ controlPlane:
   oidc: {}
   replicas: 1
   resourceRatio: 8
+  template: flatcar-stable-3602.2.1-kube-v1.25.16
 global:
   podSecurityStandards:
     enforced: true
@@ -67,6 +69,10 @@ kubectlImage:
 metadata:
   preventDeletion: false
   servicePriority: highest
+nodePools:
+  worker:
+    class: default
+    replicas: 2
 providerSpecific:
   cloudProviderInterface:
     enableVirtualServiceSharedIP: true
@@ -81,6 +87,10 @@ providerSpecific:
       retain:
         isDefault: false
         vcdStorageProfileName: ""
+  nodeClasses:
+    default:
+      catalog: giantswarm
+      template: flatcar-stable-3602.2.1-kube-v1.25.16
   userContext:
     secretRef: {}
   vmBootstrapFormat: cloud-config


### PR DESCRIPTION
This PR:

- Sets the default `nodeClass` and `nodePool` in schema/values.
The customer sets these values so they'll be overwritten but it will be helpful for E2E tests.
Alignment with https://github.com/giantswarm/cluster-vsphere/blob/main/helm/cluster-vsphere/values.yaml
- Sets `Flatcar` as the default OS.
- Sets Kubernetes version `1.25.16` by default
- Removes defaulted disk size. Otherwise it would break the FS on VMs deployed from a template with a disk >30GB

The [method](https://github.com/giantswarm/giantswarm/issues/30386) to set default nodeclass/nodepool might change in the future when we move to using the cluster shared chart.