### PR TITLE
remove default-policies and enable DNS policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add teleport support to SSH into nodes (disabled by default)
+- Enable DNS network policies from network-policies-app.
+
+### Removed
+
+- Remove default network policies from cilium-app.
 
 ## [0.16.0] - 2024-04-02
 

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -63,7 +63,8 @@ spec:
             value: "true"
 {{- if .Values.internal.ciliumNetworkPolicy.enabled }}
     defaultPolicies:
-      enabled: true
+      remove: true
+      enabled: false
       tolerations:
         - effect: NoSchedule
           operator: Exists

--- a/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/netpol-helmrelease.yaml
@@ -33,7 +33,9 @@ spec:
       retries: 30
   # Default values
   # https://github.com/giantswarm/network-policies-app/blob/main/helm/network-policies-app/values.yaml
-  # values:
+  values:
+    allowEgressToDNS:
+      enabled: true
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Remove default policies from cilium-app
- Install DNS policies from network-policies-app

Towards https://github.com/giantswarm/roadmap/issues/3261

### Testing

Description on how cluster-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for cluster-cloud-director installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
