### PR TITLE
Enable teleport by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable teleport by default.
+
 ## [0.50.0] - 2024-04-16
 
 ### Changed

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -30,7 +30,7 @@ Properties within the `.internal` top-level object
 | `internal.sandboxContainerImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"3.9"`|
 | `internal.skipRde` | **Skip RDE** - Set to true if the API schema extension is installed in the correct version in VCD to create CAPVCD entities in the API. Set to false otherwise.|**Type:** `boolean`<br/>|
 | `internal.teleport` | **Teleport**|**Type:** `object`<br/>|
-| `internal.teleport.enabled` | **Enable teleport**|**Type:** `boolean`<br/>**Default:** `false`|
+| `internal.teleport.enabled` | **Enable teleport**|**Type:** `boolean`<br/>**Default:** `true`|
 | `internal.teleport.proxyAddr` | **Teleport proxy address**|**Type:** `string`<br/>**Default:** `"teleport.giantswarm.io:443"`|
 | `internal.useAsManagementCluster` | **Display as management cluster**|**Type:** `boolean`<br/>**Default:** `false`|
 

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -730,7 +730,7 @@
                         "enabled": {
                             "type": "boolean",
                             "title": "Enable teleport",
-                            "default": false
+                            "default": true
                         },
                         "proxyAddr": {
                             "type": "string",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -62,7 +62,7 @@ internal:
     registry: gsoci.azurecr.io
     tag: "3.9"
   teleport:
-    enabled: false
+    enabled: true
     proxyAddr: teleport.giantswarm.io:443
   useAsManagementCluster: false
 kubectlImage:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3101


<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Enables teleport by default

### Testing

Description on how cluster-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for cluster-cloud-director installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
