### PR TITLE
Remove etcd and dns images from kubeadmcontrolplane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the interface to set `etcd` and `coredns` images to let kubeadm take care of it.
+
 ## [0.52.1] - 2024-05-16
 
 ### Fixed

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -98,12 +98,6 @@ Properties within the `.controlPlane` top-level object
 | `controlPlane.customNodeLabels` | **Node labels**|**Type:** `array`<br/>|
 | `controlPlane.customNodeLabels[*]` | **Custom node label**|**Type:** `string`<br/>**Example:** `"key=value"`<br/>**Value pattern:** `^[A-Za-z0-9-_\./]{1,63}=[A-Za-z0-9-_\.]{0,63}$`<br/>|
 | `controlPlane.diskSizeGB` | **Disk size**|**Type:** `integer`<br/>**Example:** `30`<br/>|
-| `controlPlane.dns` | **DNS container image**|**Type:** `object`<br/>|
-| `controlPlane.dns.imageRepository` | **Repository**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io/giantswarm"`|
-| `controlPlane.dns.imageTag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.9.4-giantswarm"`|
-| `controlPlane.etcd` | **Etcd container image**|**Type:** `object`<br/>|
-| `controlPlane.etcd.imageRepository` | **Repository**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io/giantswarm"`|
-| `controlPlane.etcd.imageTag` | **Tag**|**Type:** `string`<br/>**Default:** `"3.5.4-0-k8s"`|
 | `controlPlane.image` | **Node container image** - Set to 'gsoci.azurecr.io/giantswarm' for ignition (Flatcar) and 'projects.registry.vmware.com/tkg' for cloud-init (Ubuntu).|**Type:** `object`<br/>|
 | `controlPlane.image.repository` | **Repository**|**Type:** `string`<br/>**Default:** `"gsoci.azurecr.io/giantswarm"`|
 | `controlPlane.oidc` | **OIDC authentication**|**Type:** `object`<br/>|

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -88,15 +88,10 @@ spec:
         extraArgs:
           authorization-always-allow-paths: "/healthz,/readyz,/livez,/metrics"
           bind-address: "0.0.0.0"
-      dns:
-        imageRepository: {{ .Values.controlPlane.dns.imageRepository }}
-        imageTag: {{ .Values.controlPlane.dns.imageTag }}
       etcd:
         local:
           extraArgs:
             listen-metrics-urls: "http://0.0.0.0:2381"
-          imageRepository: {{ .Values.controlPlane.etcd.imageRepository }}
-          imageTag: {{ .Values.controlPlane.etcd.imageTag }}
       imageRepository: {{ .Values.controlPlane.image.repository }}
     {{- include "sshUsers" . | nindent 4 }}
     {{- if eq $.Values.providerSpecific.vmBootstrapFormat "ignition" }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -438,8 +438,6 @@
                 "catalog",
                 "template",
                 "replicas",
-                "dns",
-                "etcd",
                 "resourceRatio"
             ],
             "additionalProperties": false,
@@ -466,40 +464,6 @@
                     "$ref": "#/$defs/diskSizeGB",
                     "title": "Disk size",
                     "description": "Control plane node root volume size, in GB."
-                },
-                "dns": {
-                    "type": "object",
-                    "title": "DNS container image",
-                    "additionalProperties": false,
-                    "properties": {
-                        "imageRepository": {
-                            "type": "string",
-                            "title": "Repository",
-                            "default": "gsoci.azurecr.io/giantswarm"
-                        },
-                        "imageTag": {
-                            "type": "string",
-                            "title": "Tag",
-                            "default": "1.9.4-giantswarm"
-                        }
-                    }
-                },
-                "etcd": {
-                    "type": "object",
-                    "title": "Etcd container image",
-                    "additionalProperties": false,
-                    "properties": {
-                        "imageRepository": {
-                            "type": "string",
-                            "title": "Repository",
-                            "default": "gsoci.azurecr.io/giantswarm"
-                        },
-                        "imageTag": {
-                            "type": "string",
-                            "title": "Tag",
-                            "default": "3.5.4-0-k8s"
-                        }
-                    }
                 },
                 "image": {
                     "type": "object",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -23,12 +23,6 @@ connectivity:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
 controlPlane:
   catalog: giantswarm
-  dns:
-    imageRepository: gsoci.azurecr.io/giantswarm
-    imageTag: 1.9.4-giantswarm
-  etcd:
-    imageRepository: gsoci.azurecr.io/giantswarm
-    imageTag: 3.5.4-0-k8s
   image:
     repository: gsoci.azurecr.io/giantswarm
   oidc: {}


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This pr removes our ability to set etcd images (and coredns which wasn't used like that anyways). This means it will be handled automatically by kubeadm.

This also aligns with our cloud providers.

https://gigantic.slack.com/archives/CLPMFRVU6/p1712831360621509?thread_ts=1712831054.292869&cid=CLPMFRVU6

### Testing

Description on how cluster-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for cluster-cloud-director installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
