### PR TITLE
refactor: move metadata under global key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ Using `yq`, migrate to the new values layout with the following command:
 #!/bin/bash
 yq eval --inplace 'with(select(.connectivity != null);  .global.connectivity = .connectivity) |
     with(select(.baseDomain != null);                   .global.connectivity.baseDomain = .baseDomain) |
+    with(select(.metadata != null);                     .global.metadata = .metadata) |
 
     del(.connectivity) |
-    del(.baseDomain)' values.yaml
+    del(.baseDomain) |
+    del(.metadata)' values.yaml
 ```
 
 </details>
@@ -29,6 +31,7 @@ yq eval --inplace 'with(select(.connectivity != null);  .global.connectivity = .
 
 - Move Helm values property `.Values.connectivity` to `.Values.global.connectivity`.
 - Move Helm values property `.Values.baseDomain` to `.Values.global.connectivity.baseDomain`.
+- Move Helm values property `.Values.metadata` to `.Values.global.metadata`.
 
 ## [0.51.0] - 2024-05-07
 

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -133,16 +133,16 @@ Used by cluster-shared library chart to configure coredns in-cluster.
 | `kubectlImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.25.15"`|
 
 ### Metadata
-Properties within the `.metadata` top-level object
+Properties within the `.global.metadata` object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
-| `metadata.labels` | **Labels** - These labels are added to the Kubernetes resources defining this cluster.|**Type:** `object`<br/>|
-| `metadata.labels.PATTERN` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-zA-Z0-9/\._-]+$`<br/>**Value pattern:** `^[a-zA-Z0-9\._-]+$`<br/>|
-| `metadata.organization` | **Organization**|**Type:** `string`<br/>|
-| `metadata.preventDeletion` | **Prevent cluster deletion**|**Type:** `boolean`<br/>**Default:** `false`|
-| `metadata.servicePriority` | **Service priority** - The relative importance of this cluster.|**Type:** `string`<br/>**Default:** `"highest"`|
+| `global.metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
+| `global.metadata.labels` | **Labels** - These labels are added to the Kubernetes resources defining this cluster.|**Type:** `object`<br/>|
+| `global.metadata.labels.PATTERN` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-zA-Z0-9/\._-]+$`<br/>**Value pattern:** `^[a-zA-Z0-9\._-]+$`<br/>|
+| `global.metadata.organization` | **Organization**|**Type:** `string`<br/>|
+| `global.metadata.preventDeletion` | **Prevent cluster deletion**|**Type:** `boolean`<br/>**Default:** `false`|
+| `global.metadata.servicePriority` | **Service priority** - The relative importance of this cluster.|**Type:** `string`<br/>**Default:** `"highest"`|
 
 ### Node pools
 Properties within the `.nodePools` top-level object

--- a/helm/cluster-cloud-director/ci/test-wc-values.yaml
+++ b/helm/cluster-cloud-director/ci/test-wc-values.yaml
@@ -30,10 +30,6 @@ providerSpecific:
   userContext:
     secretRef:
       secretName: vcd-credentials
-metadata:
-  description: "Testing Cluster"
-  organization: giantswarm
-  servicePriority: highest
 internal:
   kubernetesVersion: v1.25.13+vmware.1
 global:
@@ -42,3 +38,7 @@ global:
       loadBalancers:
         vipSubnet: 10.205.9.254/24
     baseDomain: "test.gigantic.io"
+  metadata:
+    description: "Testing Cluster"
+    organization: giantswarm
+    servicePriority: highest

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -28,8 +28,8 @@ app: {{ include "name" . | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 cluster.x-k8s.io/cluster-name: {{ include "resource.default.name" . | quote }}
 giantswarm.io/cluster: {{ include "resource.default.name" . | quote }}
-{{- if .Values.metadata.organization }}
-giantswarm.io/organization: {{ .Values.metadata.organization | quote }}
+{{- if .Values.global.metadata.organization }}
+giantswarm.io/organization: {{ .Values.global.metadata.organization | quote }}
 {{- end }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- end -}}
@@ -48,7 +48,7 @@ helm.sh/chart: {{ include "chart" . | quote }}
 Create label to prevent accidental cluster deletion
 */}}
 {{- define "preventDeletionLabel" -}}
-{{- if $.Values.metadata.preventDeletion -}}
+{{- if $.Values.global.metadata.preventDeletion -}}
 giantswarm.io/prevent-deletion: "true"
 {{ end -}}
 {{- end -}}

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-cilium
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: {{ .Values.metadata.description | quote }}
+    cluster.giantswarm.io/description: {{ .Values.global.metadata.description | quote }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -4,13 +4,13 @@ metadata:
   name: {{ include "resource.default.name" $ }}-cloud-provider-cloud-director
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: {{ .Values.metadata.description | quote }}
+    cluster.giantswarm.io/description: {{ .Values.global.metadata.description | quote }}
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: {{ .Values.metadata.servicePriority | quote }}
+    giantswarm.io/service-priority: {{ .Values.global.metadata.servicePriority | quote }}
     {{- include "labels.common" . | nindent 4 }}
-    {{- if .Values.metadata.labels }}
-    {{- range $key, $val := .Values.metadata.labels }}
+    {{- if .Values.global.metadata.labels }}
+    {{- range $key, $val := .Values.global.metadata.labels }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
     {{- end }}

--- a/helm/cluster-cloud-director/templates/cluster.yaml
+++ b/helm/cluster-cloud-director/templates/cluster.yaml
@@ -4,13 +4,13 @@ metadata:
   name: {{ include "resource.default.name" $ }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: {{ .Values.metadata.description | quote }}
+    cluster.giantswarm.io/description: {{ .Values.global.metadata.description | quote }}
   labels:
     cluster-apps-operator.giantswarm.io/watching: ""
-    giantswarm.io/service-priority: {{ .Values.metadata.servicePriority | quote }}
+    giantswarm.io/service-priority: {{ .Values.global.metadata.servicePriority | quote }}
     {{- include "labels.common" . | nindent 4 }}
-    {{- if .Values.metadata.labels }}
-    {{- range $key, $val := .Values.metadata.labels }}
+    {{- if .Values.global.metadata.labels }}
+    {{- range $key, $val := .Values.global.metadata.labels }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
     {{- end }}

--- a/helm/cluster-cloud-director/templates/coredns-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/coredns-helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-coredns
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: {{ .Values.metadata.description | quote }}
+    cluster.giantswarm.io/description: {{ .Values.global.metadata.description | quote }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-cloud-director/templates/default-helmrepository.yaml
+++ b/helm/cluster-cloud-director/templates/default-helmrepository.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-default
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: {{ .Values.metadata.description | quote }}
+    cluster.giantswarm.io/description: {{ .Values.global.metadata.description | quote }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -17,7 +17,7 @@ metadata:
   name: {{ include "resource.default.name" $ }}-default-test
   namespace: {{ $.Release.Namespace }}
   annotations:
-    cluster.giantswarm.io/description: {{ .Values.metadata.description | quote }}
+    cluster.giantswarm.io/description: {{ .Values.global.metadata.description | quote }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -595,6 +595,54 @@
                         }
                     }
                 },
+                "metadata": {
+                    "type": "object",
+                    "title": "Metadata",
+                    "additionalProperties": false,
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "title": "Cluster description",
+                            "description": "User-friendly description of the cluster's purpose."
+                        },
+                        "labels": {
+                            "type": "object",
+                            "title": "Labels",
+                            "description": "These labels are added to the Kubernetes resources defining this cluster.",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^[a-zA-Z0-9/\\._-]+$": {
+                                    "type": "string",
+                                    "title": "Label",
+                                    "maxLength": 63,
+                                    "minLength": 0,
+                                    "pattern": "^[a-zA-Z0-9\\._-]+$"
+                                }
+                            }
+                        },
+                        "organization": {
+                            "type": "string",
+                            "title": "Organization"
+                        },
+                        "preventDeletion": {
+                            "type": "boolean",
+                            "title": "Prevent cluster deletion",
+                            "default": false
+                        },
+                        "servicePriority": {
+                            "type": "string",
+                            "title": "Service priority",
+                            "description": "The relative importance of this cluster.",
+                            "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
+                            "enum": [
+                                "highest",
+                                "medium",
+                                "lowest"
+                            ],
+                            "default": "highest"
+                        }
+                    }
+                },
                 "podSecurityStandards": {
                     "type": "object",
                     "title": "Pod Security Standards",
@@ -774,54 +822,6 @@
             "type": "string",
             "title": "Management cluster name",
             "description": "The Cluster API management cluster that manages this cluster."
-        },
-        "metadata": {
-            "type": "object",
-            "title": "Metadata",
-            "additionalProperties": false,
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "title": "Cluster description",
-                    "description": "User-friendly description of the cluster's purpose."
-                },
-                "labels": {
-                    "type": "object",
-                    "title": "Labels",
-                    "description": "These labels are added to the Kubernetes resources defining this cluster.",
-                    "additionalProperties": false,
-                    "patternProperties": {
-                        "^[a-zA-Z0-9/\\._-]+$": {
-                            "type": "string",
-                            "title": "Label",
-                            "maxLength": 63,
-                            "minLength": 0,
-                            "pattern": "^[a-zA-Z0-9\\._-]+$"
-                        }
-                    }
-                },
-                "organization": {
-                    "type": "string",
-                    "title": "Organization"
-                },
-                "preventDeletion": {
-                    "type": "boolean",
-                    "title": "Prevent cluster deletion",
-                    "default": false
-                },
-                "servicePriority": {
-                    "type": "string",
-                    "title": "Service priority",
-                    "description": "The relative importance of this cluster.",
-                    "$comment": "Defined in https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority",
-                    "enum": [
-                        "highest",
-                        "medium",
-                        "lowest"
-                    ],
-                    "default": "highest"
-                }
-            }
         },
         "nodePools": {
             "type": "object",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -35,6 +35,9 @@ global:
           sudo: ALL=(ALL) NOPASSWD:ALL
       sshTrustedUserCAKeys:
         - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io
+  metadata:
+    preventDeletion: false
+    servicePriority: highest
   podSecurityStandards:
     enforced: true
 internal:
@@ -68,9 +71,6 @@ kubectlImage:
   name: giantswarm/kubectl
   registry: gsoci.azurecr.io
   tag: 1.25.15
-metadata:
-  preventDeletion: false
-  servicePriority: highest
 nodePools:
   worker:
     class: default


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3373

Notes: 

- it's not possible to test this using the e2e CI tests because the [test cluster values](https://github.com/giantswarm/cluster-standup-teardown/blob/main/pkg/clusterbuilder/providers/capvcd/values/cluster_values.yaml) have not been updated yet (and cannot be updated until the chart refactoring is complete and released). Running the CI tests locally with manually updated values passes though:

```
Ran 18 of 27 Specs in 2644.239 seconds
SUCCESS! -- 18 Passed | 0 Failed | 0 Pending | 9 Skipped
PASS

Ginkgo ran 1 suite in 44m12.717261703s
Test Suite Passed
```

- the [documentation validation checks](https://github.com/giantswarm/cluster-cloud-director/actions/runs/8991262702/job/24698451089?pr=296) are showing as failed, but this is a weird side effect of [allowing additional properties](https://github.com/giantswarm/cluster-cloud-director/pull/297) on the root level (which is required until the refactoring is complete). The docs generate correctly when this value is reverted to `false`, **so please ignore this failing check**.

- the [schema validation checks](https://github.com/giantswarm/cluster-cloud-director/actions/runs/8991262704/job/24698451130?pr=296) fail pretty spectacularly at the moment but this will be addressed in a separate PR later in the refactoring - the schema does validate correctly, it just needs improving. **Please ignore this failing check**. 