### PR TITLE
move static route to unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changelog
+
+- Add static route commands to network setup script in Flatcar systemd unit.
+
 ## [0.51.0] - 2024-05-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the Helm chart used for deploying CAPI clusters via [CA
 
 | Cluster App Version | Kubernetes version | Flatcar Version | vApp Template Name | CPI / CSI | Comment |
 | ------------------- | ------------------ | --------------- | ------------------ | ----------- | ------- |
-| Fix in release PR   | v1.25.16        | 3815.2.1        | flatcar-stable-3815.2.1-kube-v1.25.16 | 1.2.0 / 1.3.2 | Teleport v15.1.7 |
+| v0.51.0   | v1.25.16        | 3815.2.1        | flatcar-stable-3815.2.1-kube-v1.25.16 | 1.2.0 / 1.3.2 | Teleport v15.1.7 |
 | v0.50.0             | v1.25.16        | 3602.2.1        | flatcar-stable-3602.2.1-kube-v1.25.16 | 1.2.0 / 1.3.2 |  |
 
 ## Authentication to VCD

--- a/helm/cluster-cloud-director/templates/_helpers.tpl
+++ b/helm/cluster-cloud-director/templates/_helpers.tpl
@@ -140,12 +140,6 @@ and is used to join the node to the teleport cluster.
   content: {{ tpl ($.Files.Get "files/systemd/teleport.service") . | b64enc }}
 {{- end -}}
 
-{{- define "staticRoutesCommands" -}}
-{{- range $.Values.connectivity.network.staticRoutes}}
-- sudo ip route add {{ .destination }} via {{ .via }}
-{{- end -}}
-{{- end }}
-
 {{- define "hostEntries" -}}
 {{- range $.Values.connectivity.network.hostEntries}}
 - echo "{{ .ip }}  {{ .fqdn }}" >> /etc/hosts
@@ -206,8 +200,6 @@ preKubeadmCommands:
 {{- if eq $.Values.providerSpecific.vmBootstrapFormat "cloud-config" }}
 - systemctl daemon-reload
 - systemctl enable --now static-routes.service
-{{- else if eq $.Values.providerSpecific.vmBootstrapFormat "ignition" }}
-{{- include "staticRoutesCommands" . }}
 {{- end }}
 {{- end }}
 {{- if $.Values.internal.teleport.enabled }}

--- a/helm/cluster-cloud-director/templates/_ignition.tpl
+++ b/helm/cluster-cloud-director/templates/_ignition.tpl
@@ -52,13 +52,18 @@ ignition:
           enabled: true
           contents: |
             [Unit]
-            Description=Install the networkd unit files
+            Description=Install the networkd unit files and static routes
             Requires=coreos-metadata.service
             After=set-hostname.service
             [Service]
             Type=oneshot
             RemainAfterExit=yes
             ExecStart=/usr/bin/bash -cv 'echo "$("$(find /usr/bin /usr/share/oem -name vmtoolsd -type f -executable 2>/dev/null | head -n 1)" --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
+            {{- if $.Values.connectivity.network.staticRoutes }}
+            {{- range $.Values.connectivity.network.staticRoutes}}
+            ExecStart=/usr/bin/bash -cv 'echo "sudo ip route add {{ .destination }} via {{ .via }}" >> /opt/set-networkd-units'
+            {{- end }}
+            {{- end }}
             ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
             ExecStart=/opt/set-networkd-units
             [Install]

--- a/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
+++ b/helm/cluster-cloud-director/templates/kubeadmcontrolplane.yaml
@@ -168,8 +168,6 @@ spec:
       {{- if eq $.Values.providerSpecific.vmBootstrapFormat "cloud-config" }}
       - systemctl daemon-reload
       - systemctl enable --now static-routes.service
-      {{- else if eq $.Values.providerSpecific.vmBootstrapFormat "ignition" }}
-      {{- include "staticRoutesCommands" . | nindent 6}}
       {{- end }}
       {{- end }}
       {{- if $.Values.internal.teleport.enabled }}


### PR DESCRIPTION
If a node reboots, the routes aren't installed as it happens in kubeadm.

It should be a unit in ignition. Context: https://gigantic.slack.com/archives/C02EVLE9W/p1714374192860579

I had a race condition issue when using a dedicated networkd unit so I moved the ip route add commands to the script that sets up networking.

(Rework of https://github.com/giantswarm/cluster-cloud-director/pull/293)