### PR TITLE
Fix race condition with networkd restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wait 3 seconds after restarting `networkd` to avoid race condition with first static route.
+
 ## [0.52.0] - 2024-05-15
 
-### Changelog
+### Changed
 
 - Add static route commands to network setup script in Flatcar systemd unit.
 

--- a/helm/cluster-cloud-director/templates/_ignition.tpl
+++ b/helm/cluster-cloud-director/templates/_ignition.tpl
@@ -60,6 +60,7 @@ ignition:
             RemainAfterExit=yes
             ExecStart=/usr/bin/bash -cv 'echo "$("$(find /usr/bin /usr/share/oem -name vmtoolsd -type f -executable 2>/dev/null | head -n 1)" --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
             {{- if $.Values.connectivity.network.staticRoutes }}
+            ExecStart=/usr/bin/bash -cv 'echo "sleep 3" >> /opt/set-networkd-units'
             {{- range $.Values.connectivity.network.staticRoutes}}
             ExecStart=/usr/bin/bash -cv 'echo "sudo ip route add {{ .destination }} via {{ .via }}" >> /opt/set-networkd-units'
             {{- end }}


### PR DESCRIPTION
Sometimes the first static route would not be added. Most likely because `systemd-networkd` took a bit longer to restart.

I added a 3 seconds wait which seems to fix the issue.
After rolling it to `glasgow` I haven't observed the issue.