### PR TITLE
Static routes bindsto networkd unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update example cluster manifest.
+- Move static routes to `set-static-routes` unit and use it as drop-in to `systemd-networkd`.
 
 ## [0.53.1] - 2024-06-08
 

--- a/helm/cluster-cloud-director/templates/_ignition.tpl
+++ b/helm/cluster-cloud-director/templates/_ignition.tpl
@@ -74,12 +74,19 @@ ignition:
             [Service]
             Type=oneshot
             RemainAfterExit=yes
-            ExecStart=/usr/bin/bash -cv 'echo "sleep 3" >> /opt/set-networkd-units'
+            ExecStart=/usr/bin/bash -cv 'sleep 3'
             {{- range $.Values.global.connectivity.network.staticRoutes}}
-            ExecStart=/usr/bin/bash -cv 'sudo ip route add {{ .destination }} via {{ .via }}'
+            ExecStart=/usr/bin/bash -cv 'ip route add {{ .destination }} via {{ .via }}'
             {{- end }}
             [Install]
             WantedBy=multi-user.target
+        - name: systemd-networkd.service
+          enabled: true
+          dropins:
+            - name: 10-static-routes-dependency.conf
+              contents: |
+                [Unit]
+                Upholds=set-static-routes.service
         {{- end }}
         - name: ethtool-segmentation.service
           enabled: true

--- a/helm/cluster-cloud-director/templates/_ignition.tpl
+++ b/helm/cluster-cloud-director/templates/_ignition.tpl
@@ -69,7 +69,7 @@ ignition:
           contents: |
             [Unit]
             Description=Install the static routes
-            After=systemd-networkd.service
+            After=systemd-networkd.service set-networkd-units.service
             BindsTo=systemd-networkd.service
             [Service]
             Type=oneshot

--- a/helm/cluster-cloud-director/templates/_ignition.tpl
+++ b/helm/cluster-cloud-director/templates/_ignition.tpl
@@ -52,23 +52,35 @@ ignition:
           enabled: true
           contents: |
             [Unit]
-            Description=Install the networkd unit files and static routes
+            Description=Install the networkd unit files
             Requires=coreos-metadata.service
             After=set-hostname.service
             [Service]
             Type=oneshot
             RemainAfterExit=yes
             ExecStart=/usr/bin/bash -cv 'echo "$("$(find /usr/bin /usr/share/oem -name vmtoolsd -type f -executable 2>/dev/null | head -n 1)" --cmd "info-get guestinfo.ignition.network")" > /opt/set-networkd-units'
-            {{- if $.Values.global.connectivity.network.staticRoutes }}
-            ExecStart=/usr/bin/bash -cv 'echo "sleep 3" >> /opt/set-networkd-units'
-            {{- range $.Values.global.connectivity.network.staticRoutes}}
-            ExecStart=/usr/bin/bash -cv 'echo "sudo ip route add {{ .destination }} via {{ .via }}" >> /opt/set-networkd-units'
-            {{- end }}
-            {{- end }}
             ExecStart=/usr/bin/bash -cv 'chmod u+x /opt/set-networkd-units'
             ExecStart=/opt/set-networkd-units
             [Install]
             WantedBy=multi-user.target
+        {{- if $.Values.global.connectivity.network.staticRoutes }}
+        - name: set-static-routes.service
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Install the static routes
+            After=systemd-networkd.service
+            BindsTo=systemd-networkd.service
+            [Service]
+            Type=oneshot
+            RemainAfterExit=yes
+            ExecStart=/usr/bin/bash -cv 'echo "sleep 3" >> /opt/set-networkd-units'
+            {{- range $.Values.global.connectivity.network.staticRoutes}}
+            ExecStart=/usr/bin/bash -cv 'sudo ip route add {{ .destination }} via {{ .via }}'
+            {{- end }}
+            [Install]
+            WantedBy=multi-user.target
+        {{- end }}
         - name: ethtool-segmentation.service
           enabled: true
           contents: |

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -122,9 +122,72 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "baseDomain": {
+            "type": "string",
+            "title": "Base DNS domain"
+        },
         "cluster-shared": {
             "type": "object",
             "title": "Library chart"
+        },
+        "connectivity": {
+            "type": "object",
+            "title": "Connectivity",
+            "description": "Configurations related to cluster connectivity such as container registries.",
+            "additionalProperties": false,
+            "properties": {
+                "containerRegistries": {
+                    "type": "object",
+                    "title": "Container registries",
+                    "description": "Endpoints and credentials configuration for container registries.",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "endpoint"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "credentials": {
+                                    "type": "object",
+                                    "title": "Credentials",
+                                    "description": "Credentials for the endpoint.",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "auth": {
+                                            "type": "string",
+                                            "title": "Auth",
+                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+                                        },
+                                        "identitytoken": {
+                                            "type": "string",
+                                            "title": "Identity token",
+                                            "description": "Used to authenticate the user and obtain an access token for the registry."
+                                        },
+                                        "password": {
+                                            "type": "string",
+                                            "title": "Password",
+                                            "description": "Used to authenticate for the registry with username/password."
+                                        },
+                                        "username": {
+                                            "type": "string",
+                                            "title": "Username",
+                                            "description": "Used to authenticate for the registry with username/password."
+                                        }
+                                    }
+                                },
+                                "endpoint": {
+                                    "type": "string",
+                                    "title": "Endpoint",
+                                    "description": "Endpoint for the container registry."
+                                }
+                            }
+                        }
+                    },
+                    "default": {}
+                }
+            }
         },
         "global": {
             "type": "object",
@@ -1072,69 +1135,6 @@
         "provider": {
             "type": "string",
             "title": "Cluster API provider name"
-        },
-        "baseDomain": {
-            "type": "string",
-            "title": "Base DNS domain"
-        },
-        "connectivity": {
-            "type": "object",
-            "title": "Connectivity",
-            "description": "Configurations related to cluster connectivity such as container registries.",
-            "additionalProperties": false,
-            "properties": {
-                "containerRegistries": {
-                    "type": "object",
-                    "title": "Container registries",
-                    "description": "Endpoints and credentials configuration for container registries.",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "endpoint"
-                            ],
-                            "additionalProperties": false,
-                            "properties": {
-                                "credentials": {
-                                    "type": "object",
-                                    "title": "Credentials",
-                                    "description": "Credentials for the endpoint.",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "auth": {
-                                            "type": "string",
-                                            "title": "Auth",
-                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
-                                        },
-                                        "identitytoken": {
-                                            "type": "string",
-                                            "title": "Identity token",
-                                            "description": "Used to authenticate the user and obtain an access token for the registry."
-                                        },
-                                        "password": {
-                                            "type": "string",
-                                            "title": "Password",
-                                            "description": "Used to authenticate for the registry with username/password."
-                                        },
-                                        "username": {
-                                            "type": "string",
-                                            "title": "Username",
-                                            "description": "Used to authenticate for the registry with username/password."
-                                        }
-                                    }
-                                },
-                                "endpoint": {
-                                    "type": "string",
-                                    "title": "Endpoint",
-                                    "description": "Endpoint for the container registry."
-                                }
-                            }
-                        }
-                    },
-                    "default": {}
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Because we can't set the routes as networkd units, we use imperative commands (not permanent routes). Meaning if `systemd-networkd` goes down for some reason, the routes will be lost when it is started again. This happened where resource exhaustion caused networkd to crash.

Here we use a combination of systemd flags:

- `BindsTo=systemd-networkd.service` : Stop `set-static-routes` if `systemd-networkd` goes down.
- `After=systemd-networkd.service` : Won't start `set-static-routes` if `systemd-networkd` and `set-networkd-units` is down.
- `Upholds=set-static-routes.service` : Start `set-static-routes` when `systemd-networkd` starts.

Note that the E2E tests don't test for this.

Scenarios manually tested:

- Create WC.
- Observe the routes are there.
- Restart networkd and observe the routes are still there.
- Stop and start networkd and observe the routes are still there.

We still don't cover the scenario where a NIC is disconnected from the VM and then reconnected.

/run cluster-test-suites
