### PR TITLE
Support local registry caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `.global.connectivity.localRegistryCache` Helm values and support for in-cluster, local registry cache mirrors in containerd configuration.
+  In such cases, the registry should be exposed via node ports and containerd connects via that port at 127.0.0.1 via HTTP (only allowed for this single use case).
+
 ### Changed
 
 - Update example cluster manifest.
+
+### Fixed
+
+- Fixed `containerd` config file generation when multiple registries are set with authentication
 
 ## [0.53.1] - 2024-06-08
 

--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -72,6 +72,11 @@ Configurations related to cluster connectivity such as container registries.
 | `global.connectivity.containerRegistries.*[*].credentials.password` | **Password** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
 | `global.connectivity.containerRegistries.*[*].credentials.username` | **Username** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
 | `global.connectivity.containerRegistries.*[*].endpoint` | **Endpoint** - Endpoint for the container registry.|**Type:** `string`<br/>|
+| `global.connectivity.localRegistryCache` | **Local registry cache** - Caching container registry within the cluster.|**Type:** `object`<br/>|
+| `global.connectivity.localRegistryCache.enabled` | **Enable** - Enabling this will deploy the Zot registry service in the cluster. To make use of it as a pull-through cache, you also have to specify registries to cache images for.|**Type:** `boolean`<br/>**Default:** `false`|
+| `global.connectivity.localRegistryCache.mirroredRegistries` | **Registries to cache** - Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.|**Type:** `array`<br/>**Default:** `[]`|
+| `global.connectivity.localRegistryCache.mirroredRegistries[*]` |**None**|**Type:** `string`<br/>|
+| `global.connectivity.localRegistryCache.port` | **Service port** - NodePort used by the local registry service.|**Type:** `integer`<br/>**Default:** `32767`|
 | `global.connectivity.network` | **Network**|**Type:** `object`<br/>|
 | `global.connectivity.network.controlPlaneEndpoint` | **Control plane endpoint** - Kubernetes API endpoint.|**Type:** `object`<br/>|
 | `global.connectivity.network.controlPlaneEndpoint.host` | **Host**|**Type:** `string`<br/>|

--- a/helm/cluster-cloud-director/ci/test-multiple-mirrors-with-auth-and-local-caching.yaml
+++ b/helm/cluster-cloud-director/ci/test-multiple-mirrors-with-auth-and-local-caching.yaml
@@ -1,0 +1,61 @@
+internal:
+  kubernetesVersion: v1.25.13+vmware.1
+global:
+  connectivity:
+    network:
+      loadBalancers:
+        vipSubnet: 10.205.9.254/24
+    baseDomain: "test.gigantic.io"
+    containerRegistries:
+      gsoci.azurecr.io:
+        - endpoint: zot-test-1.golem.gaws.gigantic.io
+          credentials:
+            username: example
+            password: xxxxx
+      gsociprivate.azurecr.io:
+        - endpoint: zot-test-2.golem.gaws.gigantic.io
+          credentials:
+            username: example
+            password: yyyyy
+    localRegistryCache:
+      enabled: true
+      mirroredRegistries:
+        - gsoci.azurecr.io
+        - gsociprivate.azurecr.io
+  metadata:
+    description: "Testing Cluster"
+    organization: giantswarm
+    servicePriority: highest
+  controlPlane:
+    catalog: giantswarm
+    replicas: 1
+    sizingPolicy: m1.medium
+    template: ubuntu-2004-kube-v1.25.13
+    diskSizeGB: 30
+    oidc:
+      issuerUrl: https://dex.gerbil.test.gigantic.io
+      caFile: ""
+      clientId: "dex-k8s-authenticator"
+      usernameClaim: "email"
+      groupsClaim: "groups"
+      usernamePrefix: ""
+      groupsPrefix: ""
+  nodePools:
+    worker:
+      class: default
+      replicas: 2
+  providerSpecific:
+    org: test
+    ovdc: test
+    ovdcNetwork: test
+    site: "https://test.cloud"
+    nodeClasses:
+      default:
+        catalog: giantswarm
+        sizingPolicy: m1.medium
+        template: ubuntu-2004-kube-v1.25.13
+        diskSizeGB: 30
+    userContext:
+      secretRef:
+        secretName: vcd-credentials
+

--- a/helm/cluster-cloud-director/files/etc/containerd/config.toml
+++ b/helm/cluster-cloud-director/files/etc/containerd/config.toml
@@ -28,21 +28,24 @@ sandbox_image = "{{ .Values.internal.sandboxContainerImage.registry }}/{{ .Value
   {{- range $host, $config := .Values.global.connectivity.containerRegistries }}
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{$host}}"]
       endpoint = [
+        {{- if and $.Values.global.connectivity.localRegistryCache.enabled (has $host $.Values.global.connectivity.localRegistryCache.mirroredRegistries) -}}
+        "http://127.0.0.1:{{ $.Values.global.connectivity.localRegistryCache.port }}",
+        {{- end -}}
         {{- range $value := $config -}}
         "https://{{$value.endpoint}}",
         {{- end -}}
-    ]
+      ]
   {{- end }}
 [plugins."io.containerd.grpc.v1.cri".registry.configs]
-  {{ range $host, $config := .Values.global.connectivity.containerRegistries -}}
+  {{- range $host, $config := .Values.global.connectivity.containerRegistries -}}
     {{ range $value := $config -}}
-      {{ with $value.credentials -}}
-      [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]
+      {{- with $value.credentials }}
+    [plugins."io.containerd.grpc.v1.cri".registry.configs."{{$value.endpoint}}".auth]
       {{ if and .username .password -}}
       auth = {{ printf "%s:%s" .username .password | b64enc | quote }}
       {{- else if .auth -}}
       auth = {{ .auth | quote }}
-      {{ else if .identitytoken -}}
+      {{- else if .identitytoken -}}
       identitytoken = {{ .identitytoken  | quote }}
       {{- end }}
     {{- end }}

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -122,9 +122,72 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "baseDomain": {
+            "type": "string",
+            "title": "Base DNS domain"
+        },
         "cluster-shared": {
             "type": "object",
             "title": "Library chart"
+        },
+        "connectivity": {
+            "type": "object",
+            "title": "Connectivity",
+            "description": "Configurations related to cluster connectivity such as container registries.",
+            "additionalProperties": false,
+            "properties": {
+                "containerRegistries": {
+                    "type": "object",
+                    "title": "Container registries",
+                    "description": "Endpoints and credentials configuration for container registries.",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "endpoint"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "credentials": {
+                                    "type": "object",
+                                    "title": "Credentials",
+                                    "description": "Credentials for the endpoint.",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "auth": {
+                                            "type": "string",
+                                            "title": "Auth",
+                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
+                                        },
+                                        "identitytoken": {
+                                            "type": "string",
+                                            "title": "Identity token",
+                                            "description": "Used to authenticate the user and obtain an access token for the registry."
+                                        },
+                                        "password": {
+                                            "type": "string",
+                                            "title": "Password",
+                                            "description": "Used to authenticate for the registry with username/password."
+                                        },
+                                        "username": {
+                                            "type": "string",
+                                            "title": "Username",
+                                            "description": "Used to authenticate for the registry with username/password."
+                                        }
+                                    }
+                                },
+                                "endpoint": {
+                                    "type": "string",
+                                    "title": "Endpoint",
+                                    "description": "Endpoint for the container registry."
+                                }
+                            }
+                        }
+                    },
+                    "default": {}
+                }
+            }
         },
         "global": {
             "type": "object",
@@ -1105,69 +1168,6 @@
         "provider": {
             "type": "string",
             "title": "Cluster API provider name"
-        },
-        "baseDomain": {
-            "type": "string",
-            "title": "Base DNS domain"
-        },
-        "connectivity": {
-            "type": "object",
-            "title": "Connectivity",
-            "description": "Configurations related to cluster connectivity such as container registries.",
-            "additionalProperties": false,
-            "properties": {
-                "containerRegistries": {
-                    "type": "object",
-                    "title": "Container registries",
-                    "description": "Endpoints and credentials configuration for container registries.",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "endpoint"
-                            ],
-                            "additionalProperties": false,
-                            "properties": {
-                                "credentials": {
-                                    "type": "object",
-                                    "title": "Credentials",
-                                    "description": "Credentials for the endpoint.",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "auth": {
-                                            "type": "string",
-                                            "title": "Auth",
-                                            "description": "Base64-encoded string from the concatenation of the username, a colon, and the password."
-                                        },
-                                        "identitytoken": {
-                                            "type": "string",
-                                            "title": "Identity token",
-                                            "description": "Used to authenticate the user and obtain an access token for the registry."
-                                        },
-                                        "password": {
-                                            "type": "string",
-                                            "title": "Password",
-                                            "description": "Used to authenticate for the registry with username/password."
-                                        },
-                                        "username": {
-                                            "type": "string",
-                                            "title": "Username",
-                                            "description": "Used to authenticate for the registry with username/password."
-                                        }
-                                    }
-                                },
-                                "endpoint": {
-                                    "type": "string",
-                                    "title": "Endpoint",
-                                    "description": "Endpoint for the container registry."
-                                }
-                            }
-                        }
-                    },
-                    "default": {}
-                }
-            }
         }
     }
 }

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -200,6 +200,39 @@
                             },
                             "default": {}
                         },
+                        "localRegistryCache": {
+                            "type": "object",
+                            "title": "Local registry cache",
+                            "description": "Caching container registry within the cluster.",
+                            "required": [
+                                "enabled",
+                                "port"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enable",
+                                    "description": "Enabling this will deploy the Zot registry service in the cluster. To make use of it as a pull-through cache, you also have to specify registries to cache images for.",
+                                    "default": false
+                                },
+                                "mirroredRegistries": {
+                                    "type": "array",
+                                    "title": "Registries to cache",
+                                    "description": "Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "default": []
+                                },
+                                "port": {
+                                    "type": "integer",
+                                    "title": "Service port",
+                                    "description": "NodePort used by the local registry service.",
+                                    "default": 32767
+                                }
+                            }
+                        },
                         "network": {
                             "type": "object",
                             "title": "Network",

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -5,6 +5,10 @@ connectivity:
 global:
   connectivity:
     containerRegistries: {}
+    localRegistryCache:
+      enabled: false
+      mirroredRegistries: []
+      port: 32767
     network:
       controlPlaneEndpoint:
         port: 6443


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3460

Related to: https://github.com/giantswarm/cluster/pull/178

### Testing

Description on how cluster-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for cluster-cloud-director installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
