### PR TITLE
Run kubeadm after static routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Run `kubeadm` after the static route service to fix race condition.
+
 ## [0.54.0] - 2024-06-25
 
 ### Added

--- a/helm/cluster-cloud-director/templates/_ignition.tpl
+++ b/helm/cluster-cloud-director/templates/_ignition.tpl
@@ -108,7 +108,11 @@ ignition:
               [Unit]
               # kubeadm must run after coreos-metadata populated /run/metadata directory.
               Requires=coreos-metadata.service
+              {{- if $.Values.global.connectivity.network.staticRoutes }}
+              After=set-static-routes.service
+              {{- else }}
               After=set-networkd-units.service
+              {{- end }}
               [Service]
               # Make metadata environment variables available for pre-kubeadm commands.
               EnvironmentFile=/run/metadata/*


### PR DESCRIPTION
Fixes a race condition where the `kubeadm` service would fail because it was trying to pull the `kube-apiserver` image before the static routes were installed.

/run cluster-test-suites
