### PR TITLE
 Set cilium kubeProxyReplacement to 'true'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `kubeProxyReplacement` to `'true'` instead of deprecated value `strict` in cilium values.
+
 ## [0.56.2] - 2024-07-25
 
 ### Changed

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
       mode: kubernetes
     k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
     k8sServicePort: "6443"
-    kubeProxyReplacement: true
+    kubeProxyReplacement: 'true'
     hubble:
       relay:
         enabled: true

--- a/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cilium-helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
       mode: kubernetes
     k8sServiceHost: api.{{ include "resource.default.name" $ }}.{{ .Values.global.connectivity.baseDomain }}
     k8sServicePort: "6443"
-    kubeProxyReplacement: strict
+    kubeProxyReplacement: true
     hubble:
       relay:
         enabled: true


### PR DESCRIPTION
Upstream marked 'strict' as deprecated in 1.15 and will remove it completely in 1.16.

Signed-off-by: Matias Charriere <matias@giantswarm.io>

Towards https://github.com/giantswarm/giantswarm/issues/31353

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
