### PR TITLE
Use helm release version for cpcd from releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use cloud-provider-cloud-director version from releases.
+
 ## [0.63.0] - 2024-11-07
 
 ### :warning: **Breaking change** :warning:

--- a/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/cloud-provider-cloud-director-helmrelease.yaml
@@ -22,9 +22,9 @@ spec:
   chart:
     spec:
       chart: cloud-provider-cloud-director
-      # used by renovate
-      # repo: giantswarm/cloud-provider-cloud-director-app
-      version: 0.3.1
+      {{- $_ := set $ "appName" "cloud-provider-cloud-director" }}
+      {{- $appVersion := include "cluster.app.version" $ }}
+      version: {{ $appVersion }}
       sourceRef:
         kind: HelmRepository
         name: {{ include "resource.default.name" $ }}-default


### PR DESCRIPTION
cloud-provider-cloud-director helm chart uses now the the version which is set in the release: https://github.com/giantswarm/releases/pull/1484/files#diff-3376c10a60e0b85fc9f8d0767f87b792e8381b0122f6298be0e0038419f17c48R27-R28 
