### PR TITLE
Add auditd and selinux properties to values schema

### DIFF
--- a/helm/cluster-cloud-director/README.md
+++ b/helm/cluster-cloud-director/README.md
@@ -22,6 +22,8 @@ Advanced configuration of components that are running on all nodes.
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
+| `global.components.auditd` | **Auditd** - Enable Auditd service.|**Type:** `object`<br/>|
+| `global.components.auditd.enabled` | **Enabled** - Whether or not the Auditd service shall be enabled. When true, the Auditd service is enabled. When false, the Auditd rules service is disabled.|**Type:** `boolean`<br/>**Default:** `false`|
 | `global.components.containerd` | **Containerd** - Configuration of containerd.|**Type:** `object`<br/>|
 | `global.components.containerd.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>**Default:** `{}`|
 | `global.components.containerd.containerRegistries.*` | **Registries** - Container registries and mirrors|**Type:** `array`<br/>|
@@ -41,6 +43,8 @@ Advanced configuration of components that are running on all nodes.
 | `global.components.containerd.managementClusterRegistryCache.enabled` | **Enabled** - Enabling this will configure containerd to use management cluster's Zot registry service. To make use of it as a pull-through cache, you also have to specify registries to cache images for.|**Type:** `boolean`<br/>**Default:** `true`|
 | `global.components.containerd.managementClusterRegistryCache.mirroredRegistries` | **Registries to cache** - Here you must specify each registry to cache container images for. Please also make sure to have an entry for each registry in Global > Components > Containerd > Container registries.|**Type:** `array`<br/>**Default:** `[]`|
 | `global.components.containerd.managementClusterRegistryCache.mirroredRegistries[*]` |**None**|**Type:** `string`<br/>|
+| `global.components.selinux` | **SELinux** - Configuration of SELinux.|**Type:** `object`<br/>|
+| `global.components.selinux.mode` | **SELinux mode** - Configure SELinux mode: 'enforcing', 'permissive' or 'disabled'.|**Type:** `string`<br/>**Default:** `"permissive"`|
 
 ### Connectivity
 Properties within the `.connectivity` top-level object

--- a/helm/cluster-cloud-director/values.schema.json
+++ b/helm/cluster-cloud-director/values.schema.json
@@ -543,6 +543,20 @@
                     "description": "Advanced configuration of components that are running on all nodes.",
                     "additionalProperties": false,
                     "properties": {
+                        "auditd": {
+                            "type": "object",
+                            "title": "Auditd",
+                            "description": "Enable Auditd service.",
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "Enabled",
+                                    "description": "Whether or not the Auditd service shall be enabled. When true, the Auditd service is enabled. When false, the Auditd rules service is disabled.",
+                                    "default": false
+                                }
+                            }
+                        },
                         "containerd": {
                             "type": "object",
                             "title": "Containerd",
@@ -661,6 +675,28 @@
                                             "default": []
                                         }
                                     }
+                                }
+                            }
+                        },
+                        "selinux": {
+                            "type": "object",
+                            "title": "SELinux",
+                            "description": "Configuration of SELinux.",
+                            "required": [
+                                "mode"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "mode": {
+                                    "type": "string",
+                                    "title": "SELinux mode",
+                                    "description": "Configure SELinux mode: 'enforcing', 'permissive' or 'disabled'.",
+                                    "enum": [
+                                        "enforcing",
+                                        "permissive",
+                                        "disabled"
+                                    ],
+                                    "default": "permissive"
                                 }
                             }
                         }

--- a/helm/cluster-cloud-director/values.yaml
+++ b/helm/cluster-cloud-director/values.yaml
@@ -237,6 +237,8 @@ connectivity:
   containerRegistries: {}
 global:
   components:
+    auditd:
+      enabled: false
     containerd:
       containerRegistries: {}
       localRegistryCache:
@@ -246,6 +248,8 @@ global:
       managementClusterRegistryCache:
         enabled: true
         mirroredRegistries: []
+    selinux:
+      mode: permissive
   connectivity:
     containerRegistries: {}
     localRegistryCache:


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Add auditd and selinux properties to values schema

### Testing

Description on how cluster-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

#### Other testing

Description of features to additionally test for cluster-cloud-director installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update `/examples` if required.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.

Full docs and all optional params can be found at: https://github.com/giantswarm/cluster-test-suites#%EF%B8%8F-running-tests-in-ci
-->

/run cluster-test-suites
