### PR TITLE
fix: Migrate HelmRelease resources from removed helm.toolkit.fluxcd.io/v2beta1 to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump `HelmRelease` resources from the removed `helm.toolkit.fluxcd.io/v2beta1` API to `helm.toolkit.fluxcd.io/v2` so cluster apps render on management clusters running current Flux.
+
 ## [4.8.1] - 2026-07-16
 
 ### Changed

--- a/helm/cluster-cloud-director/templates/helmreleases/cloud-provider-cloud-director-helmrelease.yaml
+++ b/helm/cluster-cloud-director/templates/helmreleases/cloud-provider-cloud-director-helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: {{ include "resource.default.name" $ }}-cloud-provider-cloud-director


### PR DESCRIPTION
Same issue as cluster-azure: the `HelmRelease` for `cloud-provider-cloud-director` used the removed `helm.toolkit.fluxcd.io/v2beta1` API, which current Flux on the management clusters no longer serves (only `v2` and `v2beta2` are available). This causes the Cluster App to fail rendering with `no matches for kind "HelmRelease" in version "helm.toolkit.fluxcd.io/v2beta1"`.

Bumps it to `helm.toolkit.fluxcd.io/v2` (GA API). All spec fields are unchanged.
